### PR TITLE
Part 2: add new import below all others

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -72,16 +72,15 @@ function getTestMetadataDeclaration(t) {
  */
 export function addMetadata({ types: t }) {
   // TODO: Refactor to properly use state.opts
-  let importExists = false;
   let beforeEachModified = false;
 
   return {
     name: 'addMetadata',
     visitor: {
-      Program(babelPath) {
+      Program({ node }) {
         const EMBER_TEST_HELPERS = '@ember/test-helpers';
         const GET_TEST_METADATA = 'getTestMetadata';
-        const imports = babelPath.node.body.filter(maybeImport => {
+        const imports = node.body.filter(maybeImport => {
           return maybeImport.type === 'ImportDeclaration';
         });
         const emberTestHelpers = imports.filter(
@@ -106,7 +105,7 @@ export function addMetadata({ types: t }) {
         }
       },
 
-      CallExpression(babelPath) {
+      CallExpression(babelPath, state) {
         // Reset at top-level module
         if (babelPath.scope.block.type === 'Program')
           beforeEachModified = false;

--- a/src/index.js
+++ b/src/index.js
@@ -88,10 +88,8 @@ export function addMetadata({ types: t }) {
           imp => imp.source.value === EMBER_TEST_HELPERS
         );
 
-        importExists =
-          emberTestHelpers !== undefined && emberTestHelpers.length;
-
-        if (importExists) {
+        if (emberTestHelpers.length > 0) {
+          // Append to existing test-helpers import
           emberTestHelpers[0].specifiers.push(t.identifier(GET_TEST_METADATA));
         } else {
           const getTestMetaDataImportSpecifier = t.importSpecifier(
@@ -102,13 +100,13 @@ export function addMetadata({ types: t }) {
             [getTestMetaDataImportSpecifier],
             t.stringLiteral(EMBER_TEST_HELPERS)
           );
-          // TODO: Refactor to insert import after last existing import statement
-          babelPath.unshiftContainer('body', getTestMetaDataImportDeclaration);
+
+          // Add new import statement below all others
+          node.body.splice(imports.length, 0, getTestMetaDataImportDeclaration);
         }
       },
 
-      CallExpression(babelPath, state) {
-        // TODO: Refactor to properly use state.opts
+      CallExpression(babelPath) {
         // Reset at top-level module
         if (babelPath.scope.block.type === 'Program')
           beforeEachModified = false;

--- a/src/index.js
+++ b/src/index.js
@@ -86,8 +86,10 @@ export function addMetadata({ types: t }) {
         const emberTestHelpers = imports.filter(
           imp => imp.source.value === EMBER_TEST_HELPERS
         );
+        const importExists =
+          emberTestHelpers !== undefined && emberTestHelpers.length > 0;
 
-        if (emberTestHelpers.length > 0) {
+        if (importExists) {
           // Append to existing test-helpers import
           emberTestHelpers[0].specifiers.push(t.identifier(GET_TEST_METADATA));
         } else {
@@ -100,7 +102,6 @@ export function addMetadata({ types: t }) {
             t.stringLiteral(EMBER_TEST_HELPERS)
           );
 
-          // Add new import statement below all others
           node.body.splice(imports.length, 0, getTestMetaDataImportDeclaration);
         }
       },

--- a/test/__fixtures__/multiple-module-one-beforeeach-new-import-output.js
+++ b/test/__fixtures__/multiple-module-one-beforeeach-new-import-output.js
@@ -1,6 +1,6 @@
-import { getTestMetadata } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
+import { getTestMetadata } from '@ember/test-helpers';
 const SELECTORS = Object.freeze({
   MOCK_SELECTOR: '[data-test-nav-bar-browse]',
 });

--- a/test/__fixtures__/one-module-one-beforeeach-new-import-output.js
+++ b/test/__fixtures__/one-module-one-beforeeach-new-import-output.js
@@ -1,6 +1,6 @@
-import { getTestMetadata } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
+import { getTestMetadata } from '@ember/test-helpers';
 const SELECTORS = Object.freeze({
   MOCK_SELECTOR: '[data-test-nav-bar-browse]',
 });


### PR DESCRIPTION
## Description
This PR changes where we place a new getTestMetadata import statement if a test-helpers import doesn't already exist. Previously we were placing the new import at the top of the file. This PR changes its placement to be below any existing import statements.

This **does not** implement the following work; those will be in separate PRs:
- refactor to use state.opts properly
- refactor to insert beforeEach above test/module calls, not skip/todo calls

## How Has This Been Tested?
npm test