### PR TITLE
Part 3: update beforeEach insertion logic

### DIFF
--- a/__tests__/__fixtures__/multiple-module-no-beforeeach-test-skip-todo-code.js
+++ b/__tests__/__fixtures__/multiple-module-no-beforeeach-test-skip-todo-code.js
@@ -13,7 +13,7 @@ module('Acceptance | browse acceptance test', function (hooks) {
     noop();
   })
 
-  skip('it renders browse page', async function (assert) {
+  test.only('it renders browse page', async function (assert) {
     await visit(BROWSE_URL);
     assert.dom(SELECTORS.MOCK_SELECTOR).exists();
   });
@@ -26,7 +26,7 @@ module('Acceptance | browse acceptance test', function (hooks) {
     noop();
   })
 
-  todo('it renders browse page', async function (assert) {
+  test.skip('it renders browse page', async function (assert) {
     await visit(BROWSE_URL);
     assert.dom(SELECTORS.MOCK_SELECTOR).exists();
   });

--- a/__tests__/__fixtures__/multiple-module-no-beforeeach-test-skip-todo-output.js
+++ b/__tests__/__fixtures__/multiple-module-no-beforeeach-test-skip-todo-output.js
@@ -14,7 +14,7 @@ module('Acceptance | browse acceptance test', function (hooks) {
     testMetadata.filePath =
       '__tests__/__fixtures__/multiple-module-no-beforeeach-test-skip-todo-code.js';
   });
-  skip('it renders browse page', async function (assert) {
+  test.only('it renders browse page', async function (assert) {
     await visit(BROWSE_URL);
     assert.dom(SELECTORS.MOCK_SELECTOR).exists();
   });
@@ -29,7 +29,7 @@ module('Acceptance | browse acceptance test', function (hooks) {
     testMetadata.filePath =
       '__tests__/__fixtures__/multiple-module-no-beforeeach-test-skip-todo-code.js';
   });
-  todo('it renders browse page', async function (assert) {
+  test.skip('it renders browse page', async function (assert) {
     await visit(BROWSE_URL);
     assert.dom(SELECTORS.MOCK_SELECTOR).exists();
   });


### PR DESCRIPTION
## Description
This PR fixes/updates the beforeEach logic so that we only insert beforeEach above the first `test` or nested `module` calls. Also use `state.opts` to store our `beforeEachModified` variable.

## Focus
The main changes are in `index.js`:
- refactored `CallExpression` visitor function
- refactored `writeTestMetadataExpressions` helper function

Changes outside of that are either formatting changes that were auto applied or updates to the related tests (i.e. "hooks.beforeEach".

## How Has This Been Tested?

`npm test`
