### PR TITLE
Part 2: implement handling no hooks

### DIFF
--- a/__tests__/__fixtures__/one-module-one-beforeeach-no-hooks-new-import-input-test.js
+++ b/__tests__/__fixtures__/one-module-one-beforeeach-no-hooks-new-import-input-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+
+module('Unit | foo', function () {
+  some.otherThing(function () {
+    noop();
+  });
+
+  test('foo', async function (assert) {
+    assert.equal('bar', 'bar');
+  });
+});

--- a/__tests__/__snapshots__/index-test.js.snap
+++ b/__tests__/__snapshots__/index-test.js.snap
@@ -63,6 +63,42 @@ module('Acceptance | browse acceptance test', function (hooks) {
 
 `;
 
+exports[`addMetadata for a module that does not pass in hooks, pass in "hooks": for a module that does not pass in hooks, pass in "hooks" 1`] = `
+
+import { module, test } from 'qunit';
+
+module('Unit | foo', function () {
+  some.otherThing(function () {
+    noop();
+  });
+
+  test('foo', async function (assert) {
+    assert.equal('bar', 'bar');
+  });
+});
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { getTestMetadata as _getTestMetadata } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+module('Unit | foo', function (hooks) {
+  some.otherThing(function () {
+    noop();
+  });
+  hooks.beforeEach(function () {
+    let testMetadata = _getTestMetadata(this);
+
+    testMetadata.filePath =
+      '__tests__/__fixtures__/one-module-one-beforeeach-no-hooks-new-import-input-test.js';
+  });
+  test('foo', async function (assert) {
+    assert.equal('bar', 'bar');
+  });
+});
+
+
+`;
+
 exports[`addMetadata for a module with a beforeEach that is passed an async function callback, getTestMetadata statements are adding correctly: for a module with a beforeEach that is passed an async function callback, getTestMetadata statements are adding correctly 1`] = `
 
 import {module, test} from 'qunit';

--- a/__tests__/index-test.js
+++ b/__tests__/index-test.js
@@ -97,5 +97,13 @@ pluginTester({
         'nested-modules-with-beforeeach-import-exists-input-test.js'
       ),
     },
+    {
+      title: 'for a module that does not pass in hooks, pass in "hooks"',
+      fixture: path.join(
+        __dirname,
+        '__fixtures__/',
+        'one-module-one-beforeeach-no-hooks-new-import-input-test.js'
+      ),
+    },
   ],
 });

--- a/__tests__/index-test.js
+++ b/__tests__/index-test.js
@@ -98,7 +98,8 @@ pluginTester({
       ),
     },
     {
-      title: 'for a module that does not pass in hooks, pass in "hooks"',
+      title:
+        "for a module's function param that does not pass in hooks, pass in hooks",
       fixture: path.join(
         __dirname,
         '__fixtures__/',


### PR DESCRIPTION
Address "no hooks" case.
If the function passed into module() has no arg passed (e.g. no "hooks") then pass in a "hooks" arg.

Testing done:
- this stand-alone repo (added test)
- a simple ember app (added similar test)
- a test file in a large, private ember app, that doesn't pass in any "hooks"