### PR TITLE
handle beforeEach arg is not inline function

### DIFF
--- a/__tests__/__fixtures__/one-module-one-beforeeach-arg-not-inline-func-test.js
+++ b/__tests__/__fixtures__/one-module-one-beforeeach-arg-not-inline-func-test.js
@@ -1,0 +1,18 @@
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { beforeEachSetup } from 'before-each-setup';
+
+const SELECTORS = Object.freeze({
+  MOCK_SELECTOR: '[data-test-nav-bar-browse]',
+});
+
+module('Acceptance | browse acceptance test', function (hooks) {
+  setupApplicationTest(hooks);
+
+  hooks.beforeEach(beforeEachSetup);
+
+  test('it renders browse page', async function (assert) {
+    await visit(BROWSE_URL);
+    assert.dom(SELECTORS.MOCK_SELECTOR).exists();
+  });
+});

--- a/__tests__/__snapshots__/index-test.js.snap
+++ b/__tests__/__snapshots__/index-test.js.snap
@@ -121,6 +121,54 @@ module('Acceptance | browse acceptance test', function (hooks) {
 
 `;
 
+exports[`addMetadata for a module with a beforeEach that is passed in an identifier (non-inline function), add our new beforeEach above theirs: for a module with a beforeEach that is passed in an identifier (non-inline function), add our new beforeEach above theirs 1`] = `
+
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { beforeEachSetup } from 'before-each-setup';
+
+const SELECTORS = Object.freeze({
+  MOCK_SELECTOR: '[data-test-nav-bar-browse]',
+});
+
+module('Acceptance | browse acceptance test', function (hooks) {
+  setupApplicationTest(hooks);
+
+  hooks.beforeEach(beforeEachSetup);
+
+  test('it renders browse page', async function (assert) {
+    await visit(BROWSE_URL);
+    assert.dom(SELECTORS.MOCK_SELECTOR).exists();
+  });
+});
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { getTestMetadata as _getTestMetadata } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+import { setupApplicationTest } from 'ember-qunit';
+import { beforeEachSetup } from 'before-each-setup';
+const SELECTORS = Object.freeze({
+  MOCK_SELECTOR: '[data-test-nav-bar-browse]',
+});
+module('Acceptance | browse acceptance test', function (hooks) {
+  setupApplicationTest(hooks);
+  hooks.beforeEach(function () {
+    let testMetadata = _getTestMetadata(this);
+
+    testMetadata.filePath =
+      '__tests__/__fixtures__/one-module-one-beforeeach-arg-not-inline-func-test.js';
+  });
+  hooks.beforeEach(beforeEachSetup);
+  test('it renders browse page', async function (assert) {
+    await visit(BROWSE_URL);
+    assert.dom(SELECTORS.MOCK_SELECTOR).exists();
+  });
+});
+
+
+`;
+
 exports[`addMetadata for a module without a beforeEach and where its function param passes in a custom hooks name, create our new beforeEach called from their custom hooks object: for a module without a beforeEach and where its function param passes in a custom hooks name, create our new beforeEach called from their custom hooks object 1`] = `
 
 import { module, test } from 'qunit';

--- a/__tests__/index-test.js
+++ b/__tests__/index-test.js
@@ -124,5 +124,14 @@ pluginTester({
         'one-module-no-beforeeach-multiple-setup-calls-test.js'
       ),
     },
+    {
+      title:
+        'for a module with a beforeEach that is passed in an identifier (non-inline function), add our new beforeEach above theirs',
+      fixture: path.join(
+        __dirname,
+        '__fixtures__/',
+        'one-module-one-beforeeach-arg-not-inline-func-test.js'
+      ),
+    },
   ],
 });

--- a/src/index.js
+++ b/src/index.js
@@ -304,8 +304,11 @@ function addMetadata({ types: t }) {
             moduleFunctionBodyArray,
             t
           );
+          const beforeEachArgIsFunction =
+            existingBeforeEach &&
+            t.isFunction(existingBeforeEach.get('arguments')[0]);
 
-          if (existingBeforeEach) {
+          if (existingBeforeEach && beforeEachArgIsFunction) {
             insertMetaDataInBeforeEach(state, existingBeforeEach, t);
           } else {
             const lastSetupCall = getLastSetupCall(


### PR DESCRIPTION
Handle case where what is passed into an existing beforeEach is not an inline function, but an identifier (of an imported function). In this case, the plugin adds a new beforeEach with testMetadata statements, above their existing one (and below any setup calls). Put another way, we only insert test metadata statements into inline functions that are passed into a beforeEach.

**Testing done:**

- this stand-alone repo (added test)
- a simple ember app (added similar test)
- an application test file in a large, private ember app, that imports a 'beforeEachSetup' which is passed into beforeEach like `hooks.beforeEach(beforeEachSetup)`