### PR TITLE
pass specific test context into getTestMetadata() instead of 'this'

### DIFF
--- a/__tests__/__snapshots__/index-test.js.snap
+++ b/__tests__/__snapshots__/index-test.js.snap
@@ -37,7 +37,6 @@ import {
   click,
   visit,
   getTestMetadata as _getTestMetadata,
-  getContext as _getContext,
 } from '@ember/test-helpers';
 const SELECTORS = Object.freeze({
   MOCK_SELECTOR: '[data-test-nav-bar-browse]',
@@ -48,7 +47,7 @@ module('Acceptance | browse acceptance test', function (hooks) {
     noop();
   });
   hooks.beforeEach(function () {
-    let testMetadata = _getTestMetadata(_getContext());
+    let testMetadata = _getTestMetadata(QUnit.config.current.testEnvironment);
 
     testMetadata.filePath =
       '__tests__/__fixtures__/one-module-one-beforeeach-import-exists-input-test.js';
@@ -78,10 +77,7 @@ test('should return proper things', function testGetDots(assert) {
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-import {
-  getTestMetadata as _getTestMetadata,
-  getContext as _getContext,
-} from '@ember/test-helpers';
+import { getTestMetadata as _getTestMetadata } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 module('Unit | Utils | test one');
 test('should return proper things', function testGetDots(assert) {
@@ -122,10 +118,7 @@ module('Acceptance | browse acceptance test', function (hooks) {
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-import {
-  getTestMetadata as _getTestMetadata,
-  getContext as _getContext,
-} from '@ember/test-helpers';
+import { getTestMetadata as _getTestMetadata } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 const SELECTORS = Object.freeze({
@@ -137,7 +130,7 @@ module('Acceptance | browse acceptance test', function (hooks) {
     noop();
   });
   hooks.beforeEach(async function () {
-    let testMetadata = _getTestMetadata(_getContext());
+    let testMetadata = _getTestMetadata(QUnit.config.current.testEnvironment);
 
     testMetadata.filePath =
       '__tests__/__fixtures__/one-module-one-async-beforeeach-new-import-input-test.js';
@@ -176,10 +169,7 @@ module('Acceptance | browse acceptance test', function (hooks) {
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-import {
-  getTestMetadata as _getTestMetadata,
-  getContext as _getContext,
-} from '@ember/test-helpers';
+import { getTestMetadata as _getTestMetadata } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { beforeEachSetup } from 'before-each-setup';
@@ -189,7 +179,7 @@ const SELECTORS = Object.freeze({
 module('Acceptance | browse acceptance test', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(function () {
-    let testMetadata = _getTestMetadata(_getContext());
+    let testMetadata = _getTestMetadata(QUnit.config.current.testEnvironment);
 
     testMetadata.filePath =
       '__tests__/__fixtures__/one-module-one-beforeeach-arg-not-inline-func-test.js';
@@ -231,7 +221,6 @@ import {
   click,
   visit,
   getTestMetadata as _getTestMetadata,
-  getContext as _getContext,
 } from '@ember/test-helpers';
 const SELECTORS = Object.freeze({
   MOCK_SELECTOR: '[data-test-nav-bar-browse]',
@@ -239,7 +228,7 @@ const SELECTORS = Object.freeze({
 module('Acceptance | browse acceptance test', function (adsHooksV2) {
   setupApplicationTest(adsHooksV2);
   adsHooksV2.beforeEach(function () {
-    let testMetadata = _getTestMetadata(_getContext());
+    let testMetadata = _getTestMetadata(QUnit.config.current.testEnvironment);
 
     testMetadata.filePath =
       '__tests__/__fixtures__/one-module-no-beforeeach-custom-hooks-name-test.js';
@@ -291,7 +280,6 @@ import { setupApplicationTest } from 'ember-qunit';
 import {
   visit,
   getTestMetadata as _getTestMetadata,
-  getContext as _getContext,
 } from '@ember/test-helpers';
 const SELECTORS = Object.freeze({
   MOCK_SELECTOR: '[data-test-nav-bar-browse]',
@@ -301,7 +289,7 @@ module('Acceptance | browse acceptance test', function (hooks) {
   setupTwo(hooks);
   setupThree(hooks);
   hooks.beforeEach(function () {
-    let testMetadata = _getTestMetadata(_getContext());
+    let testMetadata = _getTestMetadata(QUnit.config.current.testEnvironment);
 
     testMetadata.filePath =
       '__tests__/__fixtures__/one-module-no-beforeeach-multiple-setup-calls-test.js';
@@ -345,14 +333,13 @@ import { module, test } from 'qunit';
 import {
   visit,
   getTestMetadata as _getTestMetadata,
-  getContext as _getContext,
 } from '@ember/test-helpers';
 const SELECTORS = Object.freeze({
   MOCK_SELECTOR: '[data-test-nav-bar-browse]',
 });
 module('Acceptance | browse acceptance test', function (hooks) {
   hooks.beforeEach(function () {
-    let testMetadata = _getTestMetadata(_getContext());
+    let testMetadata = _getTestMetadata(QUnit.config.current.testEnvironment);
 
     testMetadata.filePath =
       '__tests__/__fixtures__/one-module-no-beforeeach-no-hooks-no-setup-test.js';
@@ -382,17 +369,14 @@ module('Unit | foo', function () {
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-import {
-  getTestMetadata as _getTestMetadata,
-  getContext as _getContext,
-} from '@ember/test-helpers';
+import { getTestMetadata as _getTestMetadata } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 module('Unit | foo', function (hooks) {
   some.otherThing(function () {
     noop();
   });
   hooks.beforeEach(function () {
-    let testMetadata = _getTestMetadata(_getContext());
+    let testMetadata = _getTestMetadata(QUnit.config.current.testEnvironment);
 
     testMetadata.filePath =
       '__tests__/__fixtures__/one-module-no-beforeeach-no-hooks-test.js';
@@ -435,10 +419,7 @@ module('Acceptance | browse acceptance test', function (hooks) {
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-import {
-  getTestMetadata as _getTestMetadata,
-  getContext as _getContext,
-} from '@ember/test-helpers';
+import { getTestMetadata as _getTestMetadata } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 const SELECTORS = Object.freeze({
@@ -450,7 +431,7 @@ module('Acceptance | browse acceptance test', function (hooks) {
     noop();
   });
   hooks.beforeEach(function () {
-    let testMetadata = _getTestMetadata(_getContext());
+    let testMetadata = _getTestMetadata(QUnit.config.current.testEnvironment);
 
     testMetadata.filePath =
       '__tests__/__fixtures__/one-module-one-beforeeach-new-import-input-test.js';
@@ -499,7 +480,6 @@ import {
   click,
   visit,
   getTestMetadata as _getTestMetadata,
-  getContext as _getContext,
 } from '@ember/test-helpers';
 const SELECTORS = Object.freeze({
   MOCK_SELECTOR: '[data-test-nav-bar-browse]',
@@ -507,7 +487,7 @@ const SELECTORS = Object.freeze({
 module('Acceptance | browse acceptance test', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(function () {
-    let testMetadata = _getTestMetadata(_getContext());
+    let testMetadata = _getTestMetadata(QUnit.config.current.testEnvironment);
 
     testMetadata.filePath =
       '__tests__/__fixtures__/one-module-no-beforeeach-test-member-input-test.js';
@@ -555,7 +535,6 @@ import {
   click,
   visit,
   getTestMetadata as _getTestMetadata,
-  getContext as _getContext,
 } from '@ember/test-helpers';
 const SELECTORS = Object.freeze({
   MOCK_SELECTOR: '[data-test-nav-bar-browse]',
@@ -563,7 +542,7 @@ const SELECTORS = Object.freeze({
 module('Acceptance | browse acceptance test', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(function () {
-    let testMetadata = _getTestMetadata(_getContext());
+    let testMetadata = _getTestMetadata(QUnit.config.current.testEnvironment);
 
     testMetadata.filePath =
       '__tests__/__fixtures__/one-module-no-beforeeach-import-exists-input-test.js';
@@ -629,10 +608,7 @@ module('Acceptance | search acceptance test', function (hooks) {
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-import {
-  getTestMetadata as _getTestMetadata,
-  getContext as _getContext,
-} from '@ember/test-helpers';
+import { getTestMetadata as _getTestMetadata } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 const SELECTORS = Object.freeze({
@@ -644,7 +620,7 @@ module('Acceptance | browse acceptance test', function (hooks) {
     noop();
   });
   hooks.beforeEach(function () {
-    let testMetadata = _getTestMetadata(_getContext());
+    let testMetadata = _getTestMetadata(QUnit.config.current.testEnvironment);
 
     testMetadata.filePath =
       '__tests__/__fixtures__/multiple-module-one-beforeeach-new-import-input-test.js';
@@ -662,7 +638,7 @@ module('Acceptance | search acceptance test', function (hooks) {
     noop();
   });
   hooks.beforeEach(function () {
-    let testMetadata = _getTestMetadata(_getContext());
+    let testMetadata = _getTestMetadata(QUnit.config.current.testEnvironment);
 
     testMetadata.filePath =
       '__tests__/__fixtures__/multiple-module-one-beforeeach-new-import-input-test.js';
@@ -720,7 +696,6 @@ import {
   click,
   visit,
   getTestMetadata as _getTestMetadata,
-  getContext as _getContext,
 } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
@@ -730,7 +705,7 @@ const SELECTORS = Object.freeze({
 module('Acceptance | browse acceptance test', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(function () {
-    let testMetadata = _getTestMetadata(_getContext());
+    let testMetadata = _getTestMetadata(QUnit.config.current.testEnvironment);
 
     testMetadata.filePath =
       '__tests__/__fixtures__/multiple-module-no-beforeeach-import-exists-input-test.js';
@@ -746,7 +721,7 @@ module('Acceptance | browse acceptance test', function (hooks) {
 module('Acceptance | search acceptance test', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(function () {
-    let testMetadata = _getTestMetadata(_getContext());
+    let testMetadata = _getTestMetadata(QUnit.config.current.testEnvironment);
 
     testMetadata.filePath =
       '__tests__/__fixtures__/multiple-module-no-beforeeach-import-exists-input-test.js';
@@ -810,7 +785,6 @@ import {
   click,
   visit,
   getTestMetadata as _getTestMetadata,
-  getContext as _getContext,
 } from '@ember/test-helpers';
 const SELECTORS = Object.freeze({
   MOCK_SELECTOR: '[data-test-nav-bar-browse]',
@@ -821,7 +795,7 @@ module('Acceptance | browse acceptance test', function (hooks) {
     noop();
   });
   hooks.beforeEach(function () {
-    let testMetadata = _getTestMetadata(_getContext());
+    let testMetadata = _getTestMetadata(QUnit.config.current.testEnvironment);
 
     testMetadata.filePath =
       '__tests__/__fixtures__/nested-modules-with-beforeeach-import-exists-input-test.js';
@@ -884,7 +858,6 @@ import {
   click,
   visit,
   getTestMetadata as _getTestMetadata,
-  getContext as _getContext,
 } from '@ember/test-helpers';
 const SELECTORS = Object.freeze({
   MOCK_SELECTOR: '[data-test-nav-bar-browse]',
@@ -892,7 +865,7 @@ const SELECTORS = Object.freeze({
 module('Acceptance | browse acceptance test', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(function () {
-    let testMetadata = _getTestMetadata(_getContext());
+    let testMetadata = _getTestMetadata(QUnit.config.current.testEnvironment);
 
     testMetadata.filePath =
       '__tests__/__fixtures__/nested-modules-no-beforeeach-import-exists-input-test.js';

--- a/__tests__/__snapshots__/index-test.js.snap
+++ b/__tests__/__snapshots__/index-test.js.snap
@@ -37,6 +37,7 @@ import {
   click,
   visit,
   getTestMetadata as _getTestMetadata,
+  getContext as _getContext,
 } from '@ember/test-helpers';
 const SELECTORS = Object.freeze({
   MOCK_SELECTOR: '[data-test-nav-bar-browse]',
@@ -47,7 +48,7 @@ module('Acceptance | browse acceptance test', function (hooks) {
     noop();
   });
   hooks.beforeEach(function () {
-    let testMetadata = _getTestMetadata(this);
+    let testMetadata = _getTestMetadata(_getContext());
 
     testMetadata.filePath =
       '__tests__/__fixtures__/one-module-one-beforeeach-import-exists-input-test.js';
@@ -77,7 +78,10 @@ test('should return proper things', function testGetDots(assert) {
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-import { getTestMetadata as _getTestMetadata } from '@ember/test-helpers';
+import {
+  getTestMetadata as _getTestMetadata,
+  getContext as _getContext,
+} from '@ember/test-helpers';
 import { module, test } from 'qunit';
 module('Unit | Utils | test one');
 test('should return proper things', function testGetDots(assert) {
@@ -118,7 +122,10 @@ module('Acceptance | browse acceptance test', function (hooks) {
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-import { getTestMetadata as _getTestMetadata } from '@ember/test-helpers';
+import {
+  getTestMetadata as _getTestMetadata,
+  getContext as _getContext,
+} from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 const SELECTORS = Object.freeze({
@@ -130,7 +137,7 @@ module('Acceptance | browse acceptance test', function (hooks) {
     noop();
   });
   hooks.beforeEach(async function () {
-    let testMetadata = _getTestMetadata(this);
+    let testMetadata = _getTestMetadata(_getContext());
 
     testMetadata.filePath =
       '__tests__/__fixtures__/one-module-one-async-beforeeach-new-import-input-test.js';
@@ -169,7 +176,10 @@ module('Acceptance | browse acceptance test', function (hooks) {
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-import { getTestMetadata as _getTestMetadata } from '@ember/test-helpers';
+import {
+  getTestMetadata as _getTestMetadata,
+  getContext as _getContext,
+} from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 import { beforeEachSetup } from 'before-each-setup';
@@ -179,7 +189,7 @@ const SELECTORS = Object.freeze({
 module('Acceptance | browse acceptance test', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(function () {
-    let testMetadata = _getTestMetadata(this);
+    let testMetadata = _getTestMetadata(_getContext());
 
     testMetadata.filePath =
       '__tests__/__fixtures__/one-module-one-beforeeach-arg-not-inline-func-test.js';
@@ -221,6 +231,7 @@ import {
   click,
   visit,
   getTestMetadata as _getTestMetadata,
+  getContext as _getContext,
 } from '@ember/test-helpers';
 const SELECTORS = Object.freeze({
   MOCK_SELECTOR: '[data-test-nav-bar-browse]',
@@ -228,7 +239,7 @@ const SELECTORS = Object.freeze({
 module('Acceptance | browse acceptance test', function (adsHooksV2) {
   setupApplicationTest(adsHooksV2);
   adsHooksV2.beforeEach(function () {
-    let testMetadata = _getTestMetadata(this);
+    let testMetadata = _getTestMetadata(_getContext());
 
     testMetadata.filePath =
       '__tests__/__fixtures__/one-module-no-beforeeach-custom-hooks-name-test.js';
@@ -280,6 +291,7 @@ import { setupApplicationTest } from 'ember-qunit';
 import {
   visit,
   getTestMetadata as _getTestMetadata,
+  getContext as _getContext,
 } from '@ember/test-helpers';
 const SELECTORS = Object.freeze({
   MOCK_SELECTOR: '[data-test-nav-bar-browse]',
@@ -289,7 +301,7 @@ module('Acceptance | browse acceptance test', function (hooks) {
   setupTwo(hooks);
   setupThree(hooks);
   hooks.beforeEach(function () {
-    let testMetadata = _getTestMetadata(this);
+    let testMetadata = _getTestMetadata(_getContext());
 
     testMetadata.filePath =
       '__tests__/__fixtures__/one-module-no-beforeeach-multiple-setup-calls-test.js';
@@ -333,13 +345,14 @@ import { module, test } from 'qunit';
 import {
   visit,
   getTestMetadata as _getTestMetadata,
+  getContext as _getContext,
 } from '@ember/test-helpers';
 const SELECTORS = Object.freeze({
   MOCK_SELECTOR: '[data-test-nav-bar-browse]',
 });
 module('Acceptance | browse acceptance test', function (hooks) {
   hooks.beforeEach(function () {
-    let testMetadata = _getTestMetadata(this);
+    let testMetadata = _getTestMetadata(_getContext());
 
     testMetadata.filePath =
       '__tests__/__fixtures__/one-module-no-beforeeach-no-hooks-no-setup-test.js';
@@ -369,14 +382,17 @@ module('Unit | foo', function () {
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-import { getTestMetadata as _getTestMetadata } from '@ember/test-helpers';
+import {
+  getTestMetadata as _getTestMetadata,
+  getContext as _getContext,
+} from '@ember/test-helpers';
 import { module, test } from 'qunit';
 module('Unit | foo', function (hooks) {
   some.otherThing(function () {
     noop();
   });
   hooks.beforeEach(function () {
-    let testMetadata = _getTestMetadata(this);
+    let testMetadata = _getTestMetadata(_getContext());
 
     testMetadata.filePath =
       '__tests__/__fixtures__/one-module-no-beforeeach-no-hooks-test.js';
@@ -419,7 +435,10 @@ module('Acceptance | browse acceptance test', function (hooks) {
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-import { getTestMetadata as _getTestMetadata } from '@ember/test-helpers';
+import {
+  getTestMetadata as _getTestMetadata,
+  getContext as _getContext,
+} from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 const SELECTORS = Object.freeze({
@@ -431,7 +450,7 @@ module('Acceptance | browse acceptance test', function (hooks) {
     noop();
   });
   hooks.beforeEach(function () {
-    let testMetadata = _getTestMetadata(this);
+    let testMetadata = _getTestMetadata(_getContext());
 
     testMetadata.filePath =
       '__tests__/__fixtures__/one-module-one-beforeeach-new-import-input-test.js';
@@ -480,6 +499,7 @@ import {
   click,
   visit,
   getTestMetadata as _getTestMetadata,
+  getContext as _getContext,
 } from '@ember/test-helpers';
 const SELECTORS = Object.freeze({
   MOCK_SELECTOR: '[data-test-nav-bar-browse]',
@@ -487,7 +507,7 @@ const SELECTORS = Object.freeze({
 module('Acceptance | browse acceptance test', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(function () {
-    let testMetadata = _getTestMetadata(this);
+    let testMetadata = _getTestMetadata(_getContext());
 
     testMetadata.filePath =
       '__tests__/__fixtures__/one-module-no-beforeeach-test-member-input-test.js';
@@ -535,6 +555,7 @@ import {
   click,
   visit,
   getTestMetadata as _getTestMetadata,
+  getContext as _getContext,
 } from '@ember/test-helpers';
 const SELECTORS = Object.freeze({
   MOCK_SELECTOR: '[data-test-nav-bar-browse]',
@@ -542,7 +563,7 @@ const SELECTORS = Object.freeze({
 module('Acceptance | browse acceptance test', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(function () {
-    let testMetadata = _getTestMetadata(this);
+    let testMetadata = _getTestMetadata(_getContext());
 
     testMetadata.filePath =
       '__tests__/__fixtures__/one-module-no-beforeeach-import-exists-input-test.js';
@@ -608,7 +629,10 @@ module('Acceptance | search acceptance test', function (hooks) {
 
       ↓ ↓ ↓ ↓ ↓ ↓
 
-import { getTestMetadata as _getTestMetadata } from '@ember/test-helpers';
+import {
+  getTestMetadata as _getTestMetadata,
+  getContext as _getContext,
+} from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
 const SELECTORS = Object.freeze({
@@ -620,7 +644,7 @@ module('Acceptance | browse acceptance test', function (hooks) {
     noop();
   });
   hooks.beforeEach(function () {
-    let testMetadata = _getTestMetadata(this);
+    let testMetadata = _getTestMetadata(_getContext());
 
     testMetadata.filePath =
       '__tests__/__fixtures__/multiple-module-one-beforeeach-new-import-input-test.js';
@@ -638,7 +662,7 @@ module('Acceptance | search acceptance test', function (hooks) {
     noop();
   });
   hooks.beforeEach(function () {
-    let testMetadata = _getTestMetadata(this);
+    let testMetadata = _getTestMetadata(_getContext());
 
     testMetadata.filePath =
       '__tests__/__fixtures__/multiple-module-one-beforeeach-new-import-input-test.js';
@@ -696,6 +720,7 @@ import {
   click,
   visit,
   getTestMetadata as _getTestMetadata,
+  getContext as _getContext,
 } from '@ember/test-helpers';
 import { module, test } from 'qunit';
 import { setupApplicationTest } from 'ember-qunit';
@@ -705,7 +730,7 @@ const SELECTORS = Object.freeze({
 module('Acceptance | browse acceptance test', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(function () {
-    let testMetadata = _getTestMetadata(this);
+    let testMetadata = _getTestMetadata(_getContext());
 
     testMetadata.filePath =
       '__tests__/__fixtures__/multiple-module-no-beforeeach-import-exists-input-test.js';
@@ -721,7 +746,7 @@ module('Acceptance | browse acceptance test', function (hooks) {
 module('Acceptance | search acceptance test', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(function () {
-    let testMetadata = _getTestMetadata(this);
+    let testMetadata = _getTestMetadata(_getContext());
 
     testMetadata.filePath =
       '__tests__/__fixtures__/multiple-module-no-beforeeach-import-exists-input-test.js';
@@ -785,6 +810,7 @@ import {
   click,
   visit,
   getTestMetadata as _getTestMetadata,
+  getContext as _getContext,
 } from '@ember/test-helpers';
 const SELECTORS = Object.freeze({
   MOCK_SELECTOR: '[data-test-nav-bar-browse]',
@@ -795,7 +821,7 @@ module('Acceptance | browse acceptance test', function (hooks) {
     noop();
   });
   hooks.beforeEach(function () {
-    let testMetadata = _getTestMetadata(this);
+    let testMetadata = _getTestMetadata(_getContext());
 
     testMetadata.filePath =
       '__tests__/__fixtures__/nested-modules-with-beforeeach-import-exists-input-test.js';
@@ -858,6 +884,7 @@ import {
   click,
   visit,
   getTestMetadata as _getTestMetadata,
+  getContext as _getContext,
 } from '@ember/test-helpers';
 const SELECTORS = Object.freeze({
   MOCK_SELECTOR: '[data-test-nav-bar-browse]',
@@ -865,7 +892,7 @@ const SELECTORS = Object.freeze({
 module('Acceptance | browse acceptance test', function (hooks) {
   setupApplicationTest(hooks);
   hooks.beforeEach(function () {
-    let testMetadata = _getTestMetadata(this);
+    let testMetadata = _getTestMetadata(_getContext());
 
     testMetadata.filePath =
       '__tests__/__fixtures__/nested-modules-no-beforeeach-import-exists-input-test.js';

--- a/src/index.js
+++ b/src/index.js
@@ -158,10 +158,10 @@ function getTestMetadataAssignment(state, t) {
  * @returns Babel variable declaration
  */
 function getTestMetadataDeclaration(state, t) {
-  const getContextIdentifier = state.opts.getContextIdentifier;
+  const contextIdentifier = state.opts.contextIdentifier;
   const getTestMetadataExpression = t.callExpression(
     t.identifier(state.opts.getTestMetadataUID.name),
-    [getContextIdentifier]
+    [contextIdentifier]
   );
 
   return t.variableDeclaration('let', [
@@ -197,7 +197,7 @@ function shouldLoadFile(filename) {
 /**
  * Babel plugin for Ember apps that adds the filepath of the test file that Babel is processing, to
  * the testMetadata. It does this by making the following transformations to the test file:
- * 1. imports "getTestMetadata" & "getContext" from @ember/test-helpers
+ * 1. imports "getTestMetadata" from @ember/test-helpers
  * 2. adds a new beforeEach or transforms any existing beforeEach to include testMetadata expressions that add
  *   filepath to testMetadata
  * @param {object} Babel object
@@ -209,7 +209,7 @@ function addMetadata({ types: t }) {
     visitor: {
       Program(babelPath, state) {
         const GET_TEST_METADATA = 'getTestMetadata';
-        const GET_CONTEXT = 'QUnit.config.current.testEnvironment';
+        const CONTEXT = 'QUnit.config.current.testEnvironment';
         const { filename } = state.file.opts;
         state.opts.shouldLoadFile = shouldLoadFile(filename);
 
@@ -223,7 +223,7 @@ function addMetadata({ types: t }) {
         state.opts.hooksIdentifier;
         state.opts.getTestMetadataUID =
           babelPath.scope.generateUidIdentifier(GET_TEST_METADATA);
-        state.opts.getContextIdentifier = t.identifier(GET_CONTEXT);
+        state.opts.contextIdentifier = t.identifier(CONTEXT);
 
         let importDeclarations = babelPath
           .get('body')
@@ -258,7 +258,7 @@ function addMetadata({ types: t }) {
        *
        * The transformed beforeEach would look like:
           hooks.beforeEach(function () {
-            let testMetadata = getTestMetadata(getContext());
+            let testMetadata = getTestMetadata(<test context>);
             testMetadata.filePath = 'test/my-test.js';
           });
        * @param {object} babelPath

--- a/src/index.js
+++ b/src/index.js
@@ -158,10 +158,9 @@ function getTestMetadataAssignment(state, t) {
  * @returns Babel variable declaration
  */
 function getTestMetadataDeclaration(state, t) {
-  const contextIdentifier = state.opts.contextIdentifier;
   const getTestMetadataExpression = t.callExpression(
     t.identifier(state.opts.getTestMetadataUID.name),
-    [contextIdentifier]
+    [t.identifier('QUnit.config.current.testEnvironment')]
   );
 
   return t.variableDeclaration('let', [
@@ -209,7 +208,6 @@ function addMetadata({ types: t }) {
     visitor: {
       Program(babelPath, state) {
         const GET_TEST_METADATA = 'getTestMetadata';
-        const CONTEXT = 'QUnit.config.current.testEnvironment';
         const { filename } = state.file.opts;
         state.opts.shouldLoadFile = shouldLoadFile(filename);
 
@@ -223,7 +221,6 @@ function addMetadata({ types: t }) {
         state.opts.hooksIdentifier;
         state.opts.getTestMetadataUID =
           babelPath.scope.generateUidIdentifier(GET_TEST_METADATA);
-        state.opts.contextIdentifier = t.identifier(CONTEXT);
 
         let importDeclarations = babelPath
           .get('body')


### PR DESCRIPTION
Update to use `QUnit.config.current.testEnvironment` instead of `this` to get test's context.
E.g. `let testMetadata = _getTestMetadata(QUnit.config.current.testEnvironment);`

Addresses case where "this" context may change due to arrow function passed into module().

Tested
- in plugin
- in simple ember app with arrow funcs, no hooks
- in private ember app