### PR TITLE
Do not skip remaining transpilation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -290,9 +290,6 @@ function addMetadata({ types: t }) {
             );
             state.opts.moduleName = moduleName.node.value;
             state.opts.moduleFunction = moduleFunction;
-          } else {
-            // skip traversing contents in this nested module
-            babelPath.skip();
           }
         }
 


### PR DESCRIPTION
- babelPath.skip() was exiting transpilation early for susequent transformations.
- remove skip and rely on the susequent moduleName conditional to skip transformations for our plugin