### PR TITLE
move env check to index

### DIFF
--- a/__tests__/index-test.js
+++ b/__tests__/index-test.js
@@ -6,9 +6,6 @@ pluginTester({
   plugin: addMetadata,
   pluginName: 'addMetadata',
   snapshot: true,
-  pluginOptions: {
-    enabled: true,
-  },
   tests: [
     {
       title:

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build": "babel src --out-dir dist --copy-files --ignore **/*.test.js",
     "lint": "eslint . --ext js,ts --cache",
     "postbuild": "rm -rf dist/**/*.test.js",
-    "test": "yarn lint && yarn test:jest",
+    "test": "yarn lint && BABEL_TEST_METADATA=true yarn test:jest",
     "test:jest": "jest"
   },
   "husky": {

--- a/readme.md
+++ b/readme.md
@@ -35,13 +35,8 @@ const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 module.exports = function (defaults) {
   let app = new EmberApp(defaults, {
     babel: {
-      plugins: [
-        [
-          require.resolve('babel-plugin-ember-test-metadata'),
-          { enabled: process.env.BABEL_TEST_METADATA }
-        ]
-      ],
-    },
+      plugins: [ require.resolve('babel-plugin-ember-test-metadata') ]
+    }
   });
 
   // additional configuration
@@ -49,3 +44,5 @@ module.exports = function (defaults) {
   return app.toTree();
 };
 ```
+
+Set the environment variable `BABEL_TEST_METADATA=true` to enable the plugin to perform its transformations.

--- a/src/index.js
+++ b/src/index.js
@@ -203,14 +203,16 @@ function shouldLoadFile(filename) {
  * @returns Babel plugin object with Program and CallExpression visitors
  */
 function addMetadata({ types: t }) {
+  console.log('env var', process.env.BABEL_TEST_METADATA);
+
+  if (!process.env.BABEL_TEST_METADATA) {
+    return {};
+  }
+
   return {
     name: 'addMetadata',
     visitor: {
       Program(babelPath, state) {
-        if (!state.opts.enabled) {
-          return;
-        }
-
         const GET_TEST_METADATA = 'getTestMetadata';
         const { filename } = state.file.opts;
         state.opts.shouldLoadFile = shouldLoadFile(filename);

--- a/src/index.js
+++ b/src/index.js
@@ -203,8 +203,6 @@ function shouldLoadFile(filename) {
  * @returns Babel plugin object with Program and CallExpression visitors
  */
 function addMetadata({ types: t }) {
-  console.log('env var', process.env.BABEL_TEST_METADATA);
-
   if (!process.env.BABEL_TEST_METADATA) {
     return {};
   }


### PR DESCRIPTION
This change moves the `process.env.BABEL_TEST_METADATA` check directly into `index`, instead of passing it in via plugin options. It circumvents an issue experienced in certain apps within our testing, where passing a plugin option surfaces a "circular structure" error.

Tested in
- this repo
- simple-app
- larger private apps