### PR TITLE
remove BABEL_TEST_METADATA early return check in index

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,7 @@ module.exports = function (defaults) {
       plugins: [
         [
           require.resolve('babel-plugin-ember-test-metadata'),
-          { enabled: process.env.BABEL_TEST_METADATA }
+          { enabled: !!process.env.BABEL_TEST_METADATA }
         ]
       ],
     }

--- a/src/index.js
+++ b/src/index.js
@@ -20,10 +20,6 @@ function shouldLoadFile(filename) {
  * @returns Babel plugin object with Program and CallExpression visitors
  */
 function addMetadata({ types: t }) {
-  if (!process.env.BABEL_TEST_METADATA) {
-    return {};
-  }
-
   return {
     name: 'addMetadata',
     visitor: {


### PR DESCRIPTION
- Removes BABEL_TEST_METADATA early return check in index, as it is not needed. Plugin option works as expected without it.
- Updates readme to reflect casting a plugin option rather than passing something that could potentially be undefined.

Tested in
- plugin tests
- simple-app, with and without BABEL_TEST_METADATA