### PR TITLE
Support embroider file path references

### DIFF
--- a/__tests__/__fixtures__/temp-test-123/embroider/123456/pathtest/embroider-prefix-test.js
+++ b/__tests__/__fixtures__/temp-test-123/embroider/123456/pathtest/embroider-prefix-test.js
@@ -1,0 +1,13 @@
+import { module, test } from 'qunit';
+import { click, getTestMetadata } from '@ember/test-helpers';
+
+module('Acceptance | example test embroider prefix', function (hooks) {
+  hooks.beforeEach(function () {
+    // noop
+  });
+
+  test('example', async function (assert) {
+    click();
+    assert(true);
+  });
+});

--- a/__tests__/__snapshots__/index-test.js.snap
+++ b/__tests__/__snapshots__/index-test.js.snap
@@ -1,5 +1,42 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`addMetadata Embroider build path: Embroider build path 1`] = `
+
+import { module, test } from 'qunit';
+import { click, getTestMetadata } from '@ember/test-helpers';
+
+module('Acceptance | example test embroider prefix', function (hooks) {
+  hooks.beforeEach(function () {
+    // noop
+  });
+
+  test('example', async function (assert) {
+    click();
+    assert(true);
+  });
+});
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+import { module, test } from 'qunit';
+import { click, getTestMetadata } from '@ember/test-helpers';
+module('Acceptance | example test embroider prefix', function (hooks) {
+  hooks.beforeEach(function () {
+    let testMetadata = getTestMetadata(QUnit.config.current.testEnvironment);
+    testMetadata.filePath = 'pathtest/embroider-prefix-test.js';
+  });
+  hooks.beforeEach(function () {
+    // noop
+  });
+  test('example', async function (assert) {
+    click();
+    assert(true);
+  });
+});
+
+
+`;
+
 exports[`addMetadata for a module with hooks it adds getTestMetadata: for a module with hooks it adds getTestMetadata 1`] = `
 
 import {module, test} from 'qunit';

--- a/__tests__/index-test.js
+++ b/__tests__/index-test.js
@@ -9,26 +9,15 @@ pluginTester({
   pluginOptions: { enabled: true },
   tests: [
     {
-      title:
-        'for a module with hooks it adds getTestMetadata',
-      fixture: path.join(
-        __dirname,
-        '__fixtures__/',
-        'with-hooks-test.js'
-      ),
+      title: 'for a module with hooks it adds getTestMetadata',
+      fixture: path.join(__dirname, '__fixtures__/', 'with-hooks-test.js'),
     },
     {
-      title:
-        'for a module with no hooks it adds test metadata',
-      fixture: path.join(
-        __dirname,
-        '__fixtures__/',
-        'without-hooks-test.js'
-      ),
+      title: 'for a module with no hooks it adds test metadata',
+      fixture: path.join(__dirname, '__fixtures__/', 'without-hooks-test.js'),
     },
     {
-      title:
-        'with existing metadata import it reuses the import',
+      title: 'with existing metadata import it reuses the import',
       fixture: path.join(
         __dirname,
         '__fixtures__/',
@@ -36,8 +25,7 @@ pluginTester({
       ),
     },
     {
-      title:
-        'with multiple sibling modules',
+      title: 'with multiple sibling modules',
       fixture: path.join(
         __dirname,
         '__fixtures__/',
@@ -45,12 +33,23 @@ pluginTester({
       ),
     },
     {
-      title:
-        'with no module callback it does not add a beforeEach',
+      title: 'with no module callback it does not add a beforeEach',
       fixture: path.join(
         __dirname,
         '__fixtures__/',
         'with-no-module-callback-test.js'
+      ),
+    },
+    {
+      title: 'Embroider build path',
+      fixture: path.join(
+        __dirname,
+        '__fixtures__/',
+        'temp-test-123',
+        'embroider',
+        '123456',
+        'pathtest',
+        'embroider-prefix-test.js'
       ),
     },
   ],

--- a/__tests__/index-test.js
+++ b/__tests__/index-test.js
@@ -10,17 +10,17 @@ pluginTester({
   tests: [
     {
       title: 'for a module with hooks it adds getTestMetadata',
-      fixture: path.join(__dirname, '__fixtures__/', 'with-hooks-test.js'),
+      fixture: path.join(__dirname, '__fixtures__', 'with-hooks-test.js'),
     },
     {
       title: 'for a module with no hooks it adds test metadata',
-      fixture: path.join(__dirname, '__fixtures__/', 'without-hooks-test.js'),
+      fixture: path.join(__dirname, '__fixtures__', 'without-hooks-test.js'),
     },
     {
       title: 'with existing metadata import it reuses the import',
       fixture: path.join(
         __dirname,
-        '__fixtures__/',
+        '__fixtures__',
         'with-get-test-metadata-test.js'
       ),
     },
@@ -28,7 +28,7 @@ pluginTester({
       title: 'with multiple sibling modules',
       fixture: path.join(
         __dirname,
-        '__fixtures__/',
+        '__fixtures__',
         'with-multiple-modules-test.js'
       ),
     },
@@ -36,7 +36,7 @@ pluginTester({
       title: 'with no module callback it does not add a beforeEach',
       fixture: path.join(
         __dirname,
-        '__fixtures__/',
+        '__fixtures__',
         'with-no-module-callback-test.js'
       ),
     },
@@ -44,7 +44,7 @@ pluginTester({
       title: 'Embroider build path',
       fixture: path.join(
         __dirname,
-        '__fixtures__/',
+        '__fixtures__',
         'temp-test-123',
         'embroider',
         '123456',

--- a/__tests__/utils-test.js
+++ b/__tests__/utils-test.js
@@ -1,4 +1,8 @@
-const { getNodeProperty, stripEmbroiderPrefix } = require('../src/utils');
+const {
+  getNodeProperty,
+  stripEmbroiderPrefix,
+  hasEmbroiderPrefix,
+} = require('../src/utils');
 
 describe('Unit | utils | getNodeProperty', () => {
   it('returns property as expected', () => {
@@ -33,5 +37,18 @@ describe('Unit | utils | stripEmbroiderPrefix', () => {
     expect(stripEmbroiderPrefix(mockEmbroiderBuildPath)).toBe(
       'tests/acceptance/my-test.js'
     );
+  });
+});
+
+describe('Unit | utils | hasEmbroiderPrefix', () => {
+  const mockEmbroiderBuildPath =
+    '/private/var/folders/abcdefg1234/T/embroider/098765/tests/acceptance/my-test.js';
+
+  it('returns true if file path includes embroider', () => {
+    expect(hasEmbroiderPrefix(mockEmbroiderBuildPath)).toBe(true);
+  });
+
+  it('returns false if file path does not include embroider', () => {
+    expect(hasEmbroiderPrefix('this/is/not-an-embroider/path')).toBe(false);
   });
 });

--- a/__tests__/utils-test.js
+++ b/__tests__/utils-test.js
@@ -1,4 +1,4 @@
-const os = require('os');
+const path = require('path');
 const { getNodeProperty, getNormalizedFilePath } = require('../src/utils');
 
 describe('Unit | utils | getNodeProperty', () => {
@@ -27,62 +27,56 @@ describe('Unit | utils | getNodeProperty', () => {
 });
 
 describe('Unit | utils | getNormalizedFilePath', () => {
-  const OS = os.platform() === 'win32' ? 'windows' : 'nixBased';
   const fileOpts = {
-    nixBased: {
-      embroiderBuildPath: {
-        root: '',
-        filename:
-          '/private/var/folders/abcdefg1234/T/embroider/098765/tests/acceptance/my-test.js',
-      },
-      embroiderBuildPathTwoEmbroiderTokens: {
-        root: '',
-        filename:
-          '/private/var/folders/embroider/abcdefg1234/T/embroider/098765/tests/acceptance/my-test.js',
-      },
-      normalFilePath: {
-        root: '',
-        filename: 'this/is/not-an-embroider/path',
-      },
+    embroiderBuildPath: {
+      root: '',
+      filename: path.join(
+        'private',
+        'var',
+        'folders',
+        'abcdefg1234',
+        'T',
+        'embroider',
+        '098765',
+        'tests',
+        'acceptance',
+        'my-test.js'
+      ),
     },
-    windows: {
-      embroiderBuildPath: {
-        root: '',
-        filename:
-          'C:\\private\\var\\folders\\abcdefg1234\\T\\embroider\\098765\\tests\\acceptance\\my-test.js',
-      },
-      embroiderBuildPathTwoEmbroiderTokens: {
-        root: '',
-        filename:
-          'C:\\private\\var\\folders\\embroider\\abcdefg1234\\T\\embroider\\098765\\tests\\acceptance\\my-test.js',
-      },
-      normalFilePath: {
-        root: '',
-        filename: 'this\\is\\not-an-embroider\\path',
-      },
+    embroiderBuildPathTwoEmbroiderTokens: {
+      root: '',
+      filename: path.join(
+        'private',
+        'var',
+        'folders',
+        'embroider',
+        'abcdefg1234',
+        'T',
+        'embroider',
+        '098765',
+        'tests',
+        'acceptance',
+        'my-test.js'
+      ),
+    },
+    normalFilePath: {
+      root: '',
+      filename: path.join('this', 'is', 'not-an-embroider', 'path'),
     },
   };
 
   it('returns stripped file path as expected', () => {
-    expect(getNormalizedFilePath(fileOpts[OS].embroiderBuildPath)).toBe(
-      OS === 'nixBased'
-        ? 'tests/acceptance/my-test.js'
-        : 'tests\\acceptance\\my-test.js'
+    expect(getNormalizedFilePath(fileOpts.embroiderBuildPath)).toBe(
+      path.join('tests', 'acceptance', 'my-test.js')
     );
     expect(
-      getNormalizedFilePath(fileOpts[OS].embroiderBuildPathTwoEmbroiderTokens)
-    ).toBe(
-      OS === 'nixBased'
-        ? 'tests/acceptance/my-test.js'
-        : 'tests\\acceptance\\my-test.js'
-    );
+      getNormalizedFilePath(fileOpts.embroiderBuildPathTwoEmbroiderTokens)
+    ).toBe(path.join('tests', 'acceptance', 'my-test.js'));
   });
 
   it('returns unmodified file path when path does not include "embroider" as a segment', () => {
-    expect(getNormalizedFilePath(fileOpts[OS].normalFilePath)).toBe(
-      OS === 'nixBased'
-        ? 'this/is/not-an-embroider/path'
-        : 'this\\is\\not-an-embroider\\path'
+    expect(getNormalizedFilePath(fileOpts.normalFilePath)).toBe(
+      path.join('this', 'is', 'not-an-embroider', 'path')
     );
   });
 });

--- a/__tests__/utils-test.js
+++ b/__tests__/utils-test.js
@@ -1,8 +1,5 @@
 const path = require('path');
-const {
-  getNodeProperty,
-  getEmbroiderStrippedPrefixPath,
-} = require('../src/utils');
+const { getNodeProperty, getNormalizedFilePath } = require('../src/utils');
 
 describe('Unit | utils | getNodeProperty', () => {
   it('returns property as expected', () => {
@@ -29,33 +26,35 @@ describe('Unit | utils | getNodeProperty', () => {
   });
 });
 
-describe('Unit | utils | getEmbroiderStrippedPrefixPath', () => {
+describe('Unit | utils | getNormalizedFilePath', () => {
   const embroiderBuildPath =
     '/private/var/folders/abcdefg1234/T/embroider/098765/tests/acceptance/my-test.js';
   const embroiderBuildPathTwoEmbroiderTokens =
     '/private/var/folders/embroider/abcdefg1234/T/embroider/098765/tests/acceptance/my-test.js';
 
   it('returns stripped file path as expected', () => {
-    expect(getEmbroiderStrippedPrefixPath(embroiderBuildPath)).toBe(
-      'tests/acceptance/my-test.js'
-    );
     expect(
-      getEmbroiderStrippedPrefixPath(embroiderBuildPathTwoEmbroiderTokens)
+      getNormalizedFilePath({ root: '', filename: embroiderBuildPath })
+    ).toBe('tests/acceptance/my-test.js');
+    expect(
+      getNormalizedFilePath({
+        root: '',
+        filename: embroiderBuildPathTwoEmbroiderTokens,
+      })
     ).toBe('tests/acceptance/my-test.js');
   });
 
-  it('returns undefined if file path does not include "embroider" as a segment', () => {
+  it('returns unmodified file path when path does not include "embroider" as a segment', () => {
     expect(
-      getEmbroiderStrippedPrefixPath('this/is/not-an-embroider/path')
-    ).toBe(undefined);
-  });
-
-  it('returns undefined if file path is not a string', () => {
-    expect(getEmbroiderStrippedPrefixPath({})).toBe(undefined);
+      getNormalizedFilePath({
+        root: '',
+        filename: 'this/is/not-an-embroider/path',
+      })
+    ).toBe('this/is/not-an-embroider/path');
   });
 });
 
-describe('Unit | utils | getEmbroiderStrippedPrefixPath with Windows path', () => {
+describe('Unit | utils | getNormalizedFilePath with Windows path', () => {
   const originalPathSeperator = path.sep;
   const windowsEmbroiderBuildPath =
     'C:\\private\\var\\folders\\abcdefg1234\\T\\embroider\\098765\\tests\\acceptance\\my-test.js';
@@ -69,8 +68,8 @@ describe('Unit | utils | getEmbroiderStrippedPrefixPath with Windows path', () =
   });
 
   it('returns stripped file path as expected', () => {
-    expect(getEmbroiderStrippedPrefixPath(windowsEmbroiderBuildPath)).toBe(
-      'tests\\acceptance\\my-test.js'
-    );
+    expect(
+      getNormalizedFilePath({ root: '', filename: windowsEmbroiderBuildPath })
+    ).toBe('tests\\acceptance\\my-test.js');
   });
 });

--- a/__tests__/utils-test.js
+++ b/__tests__/utils-test.js
@@ -1,4 +1,4 @@
-const path = require('path');
+const os = require('os');
 const { getNodeProperty, getNormalizedFilePath } = require('../src/utils');
 
 describe('Unit | utils | getNodeProperty', () => {
@@ -27,49 +27,62 @@ describe('Unit | utils | getNodeProperty', () => {
 });
 
 describe('Unit | utils | getNormalizedFilePath', () => {
-  const embroiderBuildPath =
-    '/private/var/folders/abcdefg1234/T/embroider/098765/tests/acceptance/my-test.js';
-  const embroiderBuildPathTwoEmbroiderTokens =
-    '/private/var/folders/embroider/abcdefg1234/T/embroider/098765/tests/acceptance/my-test.js';
+  const OS = os.platform() === 'win32' ? 'windows' : 'nixBased';
+  const fileOpts = {
+    nixBased: {
+      embroiderBuildPath: {
+        root: '',
+        filename:
+          '/private/var/folders/abcdefg1234/T/embroider/098765/tests/acceptance/my-test.js',
+      },
+      embroiderBuildPathTwoEmbroiderTokens: {
+        root: '',
+        filename:
+          '/private/var/folders/embroider/abcdefg1234/T/embroider/098765/tests/acceptance/my-test.js',
+      },
+      normalFilePath: {
+        root: '',
+        filename: 'this/is/not-an-embroider/path',
+      },
+    },
+    windows: {
+      embroiderBuildPath: {
+        root: '',
+        filename:
+          'C:\\private\\var\\folders\\abcdefg1234\\T\\embroider\\098765\\tests\\acceptance\\my-test.js',
+      },
+      embroiderBuildPathTwoEmbroiderTokens: {
+        root: '',
+        filename:
+          'C:\\private\\var\\folders\\embroider\\abcdefg1234\\T\\embroider\\098765\\tests\\acceptance\\my-test.js',
+      },
+      normalFilePath: {
+        root: '',
+        filename: 'this\\is\\not-an-embroider\\path',
+      },
+    },
+  };
 
   it('returns stripped file path as expected', () => {
+    expect(getNormalizedFilePath(fileOpts[OS].embroiderBuildPath)).toBe(
+      OS === 'nixBased'
+        ? 'tests/acceptance/my-test.js'
+        : 'tests\\acceptance\\my-test.js'
+    );
     expect(
-      getNormalizedFilePath({ root: '', filename: embroiderBuildPath })
-    ).toBe('tests/acceptance/my-test.js');
-    expect(
-      getNormalizedFilePath({
-        root: '',
-        filename: embroiderBuildPathTwoEmbroiderTokens,
-      })
-    ).toBe('tests/acceptance/my-test.js');
+      getNormalizedFilePath(fileOpts[OS].embroiderBuildPathTwoEmbroiderTokens)
+    ).toBe(
+      OS === 'nixBased'
+        ? 'tests/acceptance/my-test.js'
+        : 'tests\\acceptance\\my-test.js'
+    );
   });
 
   it('returns unmodified file path when path does not include "embroider" as a segment', () => {
-    expect(
-      getNormalizedFilePath({
-        root: '',
-        filename: 'this/is/not-an-embroider/path',
-      })
-    ).toBe('this/is/not-an-embroider/path');
-  });
-});
-
-describe('Unit | utils | getNormalizedFilePath with Windows path', () => {
-  const originalPathSeperator = path.sep;
-  const windowsEmbroiderBuildPath =
-    'C:\\private\\var\\folders\\abcdefg1234\\T\\embroider\\098765\\tests\\acceptance\\my-test.js';
-
-  beforeEach(() => {
-    path.sep = '\\';
-  });
-
-  afterEach(() => {
-    path.sep = originalPathSeperator;
-  });
-
-  it('returns stripped file path as expected', () => {
-    expect(
-      getNormalizedFilePath({ root: '', filename: windowsEmbroiderBuildPath })
-    ).toBe('tests\\acceptance\\my-test.js');
+    expect(getNormalizedFilePath(fileOpts[OS].normalFilePath)).toBe(
+      OS === 'nixBased'
+        ? 'this/is/not-an-embroider/path'
+        : 'this\\is\\not-an-embroider\\path'
+    );
   });
 });

--- a/__tests__/utils-test.js
+++ b/__tests__/utils-test.js
@@ -2,7 +2,6 @@ const path = require('path');
 const {
   getNodeProperty,
   getEmbroiderStrippedPrefixPath,
-  hasEmbroiderPrefix,
 } = require('../src/utils');
 
 describe('Unit | utils | getNodeProperty', () => {
@@ -45,12 +44,18 @@ describe('Unit | utils | getEmbroiderStrippedPrefixPath', () => {
     ).toBe('tests/acceptance/my-test.js');
   });
 
+  it('returns undefined if file path does not include "embroider" as a segment', () => {
+    expect(
+      getEmbroiderStrippedPrefixPath('this/is/not-an-embroider/path')
+    ).toBe(undefined);
+  });
+
   it('returns undefined if file path is not a string', () => {
     expect(getEmbroiderStrippedPrefixPath({})).toBe(undefined);
   });
 });
 
-describe('Unit | utils | getEmbroiderStrippedPrefixPath in Windows', () => {
+describe('Unit | utils | getEmbroiderStrippedPrefixPath with Windows path', () => {
   const originalPathSeperator = path.sep;
   const windowsEmbroiderBuildPath =
     'C:\\private\\var\\folders\\abcdefg1234\\T\\embroider\\098765\\tests\\acceptance\\my-test.js';
@@ -67,22 +72,5 @@ describe('Unit | utils | getEmbroiderStrippedPrefixPath in Windows', () => {
     expect(getEmbroiderStrippedPrefixPath(windowsEmbroiderBuildPath)).toBe(
       'tests\\acceptance\\my-test.js'
     );
-  });
-});
-
-describe('Unit | utils | hasEmbroiderPrefix', () => {
-  const embroiderBuildPath =
-    '/private/var/folders/abcdefg1234/T/embroider/098765/tests/acceptance/my-test.js';
-
-  it('returns true if file path includes "embroider"', () => {
-    expect(hasEmbroiderPrefix(embroiderBuildPath)).toBe(true);
-  });
-
-  it('returns false if file path does not include "embroider"', () => {
-    expect(hasEmbroiderPrefix('this/is/not-an-embroider/path')).toBe(false);
-  });
-
-  it('returns undefined if file path is not a string', () => {
-    expect(hasEmbroiderPrefix({})).toBe(undefined);
   });
 });

--- a/__tests__/utils-test.js
+++ b/__tests__/utils-test.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const {
   getNodeProperty,
   getEmbroiderStrippedPrefixPath,
@@ -30,23 +31,18 @@ describe('Unit | utils | getNodeProperty', () => {
 });
 
 describe('Unit | utils | getEmbroiderStrippedPrefixPath', () => {
-  const mockEmbroiderBuildPath =
+  const embroiderBuildPath =
     '/private/var/folders/abcdefg1234/T/embroider/098765/tests/acceptance/my-test.js';
-  const mockEmbroiderBuildPathTwoEmbroiderTokens =
+  const embroiderBuildPathTwoEmbroiderTokens =
     '/private/var/folders/embroider/abcdefg1234/T/embroider/098765/tests/acceptance/my-test.js';
-  const mockWindowsEmbroiderBuildPath =
-    'C:\\private\\var\\folders\\abcdefg1234\\T\\embroider\\098765\\tests\\acceptance\\my-test.js';
 
   it('returns stripped file path as expected', () => {
-    expect(getEmbroiderStrippedPrefixPath(mockEmbroiderBuildPath)).toBe(
+    expect(getEmbroiderStrippedPrefixPath(embroiderBuildPath)).toBe(
       'tests/acceptance/my-test.js'
     );
     expect(
-      getEmbroiderStrippedPrefixPath(mockEmbroiderBuildPathTwoEmbroiderTokens)
+      getEmbroiderStrippedPrefixPath(embroiderBuildPathTwoEmbroiderTokens)
     ).toBe('tests/acceptance/my-test.js');
-    expect(getEmbroiderStrippedPrefixPath(mockWindowsEmbroiderBuildPath)).toBe(
-      'tests\\acceptance\\my-test.js'
-    );
   });
 
   it('returns undefined if file path is not a string', () => {
@@ -54,12 +50,32 @@ describe('Unit | utils | getEmbroiderStrippedPrefixPath', () => {
   });
 });
 
+describe('Unit | utils | getEmbroiderStrippedPrefixPath in Windows', () => {
+  const originalPathSeperator = path.sep;
+  const windowsEmbroiderBuildPath =
+    'C:\\private\\var\\folders\\abcdefg1234\\T\\embroider\\098765\\tests\\acceptance\\my-test.js';
+
+  beforeEach(() => {
+    path.sep = '\\';
+  });
+
+  afterEach(() => {
+    path.sep = originalPathSeperator;
+  });
+
+  it('returns stripped file path as expected', () => {
+    expect(getEmbroiderStrippedPrefixPath(windowsEmbroiderBuildPath)).toBe(
+      'tests\\acceptance\\my-test.js'
+    );
+  });
+});
+
 describe('Unit | utils | hasEmbroiderPrefix', () => {
-  const mockEmbroiderBuildPath =
+  const embroiderBuildPath =
     '/private/var/folders/abcdefg1234/T/embroider/098765/tests/acceptance/my-test.js';
 
   it('returns true if file path includes "embroider"', () => {
-    expect(hasEmbroiderPrefix(mockEmbroiderBuildPath)).toBe(true);
+    expect(hasEmbroiderPrefix(embroiderBuildPath)).toBe(true);
   });
 
   it('returns false if file path does not include "embroider"', () => {

--- a/__tests__/utils-test.js
+++ b/__tests__/utils-test.js
@@ -1,6 +1,6 @@
 const {
   getNodeProperty,
-  stripEmbroiderPrefix,
+  getEmbroiderStrippedPrefixPath,
   hasEmbroiderPrefix,
 } = require('../src/utils');
 
@@ -29,14 +29,23 @@ describe('Unit | utils | getNodeProperty', () => {
   });
 });
 
-describe('Unit | utils | stripEmbroiderPrefix', () => {
+describe('Unit | utils | getEmbroiderStrippedPrefixPath', () => {
   const mockEmbroiderBuildPath =
     '/private/var/folders/abcdefg1234/T/embroider/098765/tests/acceptance/my-test.js';
+  const mockWindowsEmbroiderBuildPath =
+    'C:\\private\\var\\folders\\abcdefg1234\\T\\embroider\\098765\\tests\\acceptance\\my-test.js';
 
   it('returns stripped file path as expected', () => {
-    expect(stripEmbroiderPrefix(mockEmbroiderBuildPath)).toBe(
+    expect(getEmbroiderStrippedPrefixPath(mockEmbroiderBuildPath)).toBe(
       'tests/acceptance/my-test.js'
     );
+    expect(getEmbroiderStrippedPrefixPath(mockWindowsEmbroiderBuildPath)).toBe(
+      'tests\\acceptance\\my-test.js'
+    );
+  });
+
+  it('returns undefined if file path is not a string', () => {
+    expect(getEmbroiderStrippedPrefixPath({})).toBe(undefined);
   });
 });
 
@@ -44,11 +53,15 @@ describe('Unit | utils | hasEmbroiderPrefix', () => {
   const mockEmbroiderBuildPath =
     '/private/var/folders/abcdefg1234/T/embroider/098765/tests/acceptance/my-test.js';
 
-  it('returns true if file path includes embroider', () => {
+  it('returns true if file path includes "embroider"', () => {
     expect(hasEmbroiderPrefix(mockEmbroiderBuildPath)).toBe(true);
   });
 
-  it('returns false if file path does not include embroider', () => {
+  it('returns false if file path does not include "embroider"', () => {
     expect(hasEmbroiderPrefix('this/is/not-an-embroider/path')).toBe(false);
+  });
+
+  it('returns undefined if file path is not a string', () => {
+    expect(hasEmbroiderPrefix({})).toBe(undefined);
   });
 });

--- a/__tests__/utils-test.js
+++ b/__tests__/utils-test.js
@@ -32,6 +32,8 @@ describe('Unit | utils | getNodeProperty', () => {
 describe('Unit | utils | getEmbroiderStrippedPrefixPath', () => {
   const mockEmbroiderBuildPath =
     '/private/var/folders/abcdefg1234/T/embroider/098765/tests/acceptance/my-test.js';
+  const mockEmbroiderBuildPathTwoEmbroiderTokens =
+    '/private/var/folders/embroider/abcdefg1234/T/embroider/098765/tests/acceptance/my-test.js';
   const mockWindowsEmbroiderBuildPath =
     'C:\\private\\var\\folders\\abcdefg1234\\T\\embroider\\098765\\tests\\acceptance\\my-test.js';
 
@@ -39,6 +41,9 @@ describe('Unit | utils | getEmbroiderStrippedPrefixPath', () => {
     expect(getEmbroiderStrippedPrefixPath(mockEmbroiderBuildPath)).toBe(
       'tests/acceptance/my-test.js'
     );
+    expect(
+      getEmbroiderStrippedPrefixPath(mockEmbroiderBuildPathTwoEmbroiderTokens)
+    ).toBe('tests/acceptance/my-test.js');
     expect(getEmbroiderStrippedPrefixPath(mockWindowsEmbroiderBuildPath)).toBe(
       'tests\\acceptance\\my-test.js'
     );

--- a/__tests__/utils-test.js
+++ b/__tests__/utils-test.js
@@ -1,4 +1,4 @@
-const getNodeProperty = require('../src/utils');
+const { getNodeProperty, stripEmbroiderPrefix } = require('../src/utils');
 
 describe('Unit | utils | getNodeProperty', () => {
   it('returns property as expected', () => {
@@ -22,5 +22,16 @@ describe('Unit | utils | getNodeProperty', () => {
     expect(getNodeProperty(emptyNode, 'volume.level')).toBe(undefined);
     expect(getNodeProperty(null, 'volume.level')).toBe(undefined);
     expect(getNodeProperty({}, 'volume.level')).toBe(undefined);
+  });
+});
+
+describe('Unit | utils | stripEmbroiderPrefix', () => {
+  const mockEmbroiderBuildPath =
+    '/private/var/folders/abcdefg1234/T/embroider/098765/tests/acceptance/my-test.js';
+
+  it('returns stripped file path as expected', () => {
+    expect(stripEmbroiderPrefix(mockEmbroiderBuildPath)).toBe(
+      'tests/acceptance/my-test.js'
+    );
   });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const getNodeProperty = require('./utils.js');
+const { getNodeProperty } = require('./utils.js');
 
 /**
  * Checks for files ending with "-test.js" or "_test.js"

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,9 @@
 const path = require('path');
-const { getNodeProperty } = require('./utils.js');
+const {
+  getNodeProperty,
+  getEmbroiderStrippedPrefixPath,
+  hasEmbroiderPrefix,
+} = require('./utils.js');
 
 /**
  * Checks for files ending with "-test.js" or "_test.js"
@@ -112,7 +116,12 @@ function addMetadata({ types: t }) {
           ),
         ]);
 
-        const { root, filename } = state.file.opts;
+        let { root, filename } = state.file.opts;
+
+        if (hasEmbroiderPrefix(filename)) {
+          filename = getEmbroiderStrippedPrefixPath(filename);
+        }
+
         const relativeFilePath = path.relative(root, filename);
 
         const testMetadataAssignment = t.expressionStatement(

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,4 @@
-const path = require('path');
-const {
-  getNodeProperty,
-  getEmbroiderStrippedPrefixPath,
-  hasEmbroiderPrefix,
-} = require('./utils.js');
+const { getNodeProperty, getNormalizedFilePath } = require('./utils.js');
 
 /**
  * Checks for files ending with "-test.js" or "_test.js"
@@ -116,13 +111,7 @@ function addMetadata({ types: t }) {
           ),
         ]);
 
-        let { root, filename } = state.file.opts;
-
-        if (hasEmbroiderPrefix(filename)) {
-          filename = getEmbroiderStrippedPrefixPath(filename);
-        }
-
-        const relativeFilePath = path.relative(root, filename);
+        const relativeFilePath = getNormalizedFilePath(state.file.opts);
 
         const testMetadataAssignment = t.expressionStatement(
           t.assignmentExpression(

--- a/src/utils.js
+++ b/src/utils.js
@@ -33,24 +33,17 @@ function getNodeProperty(node, path) {
 }
 
 /**
- * Check if the file path follows an Embroider build pattern
- * @param {string} filepath
- * @returns boolean
- */
-function hasEmbroiderPrefix(filepath) {
-  if (typeof filepath !== 'string') return;
-
-  const separator = filepath.includes('\\') ? '\\' : '/';
-  return filepath.split(separator).includes('embroider');
-}
-
-/**
  * Get a file path with the Embroider prefix segments stripped out
  * @param {string} filepath  E.g. /private/var/folders/abcdefg1234/T/embroider/098765/tests/acceptance/my-test.js
  * @returns {string} E.g. tests/acceptance/my-test.js
  */
 function getEmbroiderStrippedPrefixPath(filepath) {
-  if (typeof filepath !== 'string') return;
+  if (
+    typeof filepath !== 'string' ||
+    !filepath.split(path.sep).includes('embroider')
+  ) {
+    return;
+  }
 
   const RELATIVE_PATH_ROOT = 2;
   const tokens = filepath.split(path.sep);
@@ -62,5 +55,4 @@ function getEmbroiderStrippedPrefixPath(filepath) {
 module.exports = {
   getNodeProperty,
   getEmbroiderStrippedPrefixPath,
-  hasEmbroiderPrefix,
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,5 @@
+const path = require('path');
+
 /**
  * Utility to get a property from a given path
  * @param {object} node
@@ -50,11 +52,11 @@ function hasEmbroiderPrefix(filepath) {
 function getEmbroiderStrippedPrefixPath(filepath) {
   if (typeof filepath !== 'string') return;
 
-  const separator = filepath.includes('\\') ? '\\' : '/';
-  const tokens = filepath.split(separator);
+  const RELATIVE_PATH_ROOT = 2;
+  const tokens = filepath.split(path.sep);
 
-  tokens.splice(0, tokens.lastIndexOf('embroider') + 2);
-  return tokens.join(separator);
+  tokens.splice(0, tokens.lastIndexOf('embroider') + RELATIVE_PATH_ROOT);
+  return tokens.join(path.sep);
 }
 
 module.exports = {

--- a/src/utils.js
+++ b/src/utils.js
@@ -33,26 +33,25 @@ function getNodeProperty(node, path) {
 }
 
 /**
- * Get a file path with the Embroider prefix segments stripped out
- * @param {string} filepath  E.g. /private/var/folders/abcdefg1234/T/embroider/098765/tests/acceptance/my-test.js
+ * Get a normalized file path. If Embroider prefix is present, strip it out
+ * @param {object} fileOpts Babel state.file.opts which include root and filename props
  * @returns {string} E.g. tests/acceptance/my-test.js
  */
-function getEmbroiderStrippedPrefixPath(filepath) {
-  if (
-    typeof filepath !== 'string' ||
-    !filepath.split(path.sep).includes('embroider')
-  ) {
-    return;
+function getNormalizedFilePath(fileOpts) {
+  let { root, filename } = fileOpts;
+  const tokens = filename.split(path.sep);
+
+  if (tokens.includes('embroider')) {
+    const RELATIVE_PATH_ROOT = 2;
+
+    tokens.splice(0, tokens.lastIndexOf('embroider') + RELATIVE_PATH_ROOT);
+    filename = tokens.join(path.sep);
   }
 
-  const RELATIVE_PATH_ROOT = 2;
-  const tokens = filepath.split(path.sep);
-
-  tokens.splice(0, tokens.lastIndexOf('embroider') + RELATIVE_PATH_ROOT);
-  return tokens.join(path.sep);
+  return path.relative(root, filename);
 }
 
 module.exports = {
   getNodeProperty,
-  getEmbroiderStrippedPrefixPath,
+  getNormalizedFilePath,
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -53,7 +53,7 @@ function getEmbroiderStrippedPrefixPath(filepath) {
   const separator = filepath.includes('\\') ? '\\' : '/';
   const tokens = filepath.split(separator);
 
-  tokens.splice(0, tokens.indexOf('embroider') + 2);
+  tokens.splice(0, tokens.lastIndexOf('embroider') + 2);
   return tokens.join(separator);
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -30,4 +30,21 @@ function getNodeProperty(node, path) {
   return property;
 }
 
-module.exports = getNodeProperty;
+function stripEmbroiderPrefix(filepath) {
+  if (typeof filepath !== 'string') {
+    return;
+  }
+
+  let separator = '/';
+  const windowsSeparator = '\\';
+
+  if (filepath.includes(windowsSeparator)) {
+    separator = windowsSeparator;
+  }
+
+  const tokens = filepath.split(separator);
+  tokens.splice(0, tokens.indexOf('embroider') + 2);
+  return tokens.join(separator);
+}
+
+module.exports = { getNodeProperty, stripEmbroiderPrefix };

--- a/src/utils.js
+++ b/src/utils.js
@@ -46,8 +46,8 @@ function getNormalizedFilePath(fileOpts) {
     const RELATIVE_PATH_ROOT = 2;
 
     tokens.splice(0, tokens.lastIndexOf(EMBROIDER) + RELATIVE_PATH_ROOT);
-    filename = tokens.join(path.sep);
   }
+  filename = tokens.join(path.sep);
 
   return path.relative(root, filename);
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -40,11 +40,12 @@ function getNodeProperty(node, path) {
 function getNormalizedFilePath(fileOpts) {
   let { root, filename } = fileOpts;
   const tokens = filename.split(path.sep);
+  const EMBROIDER = 'embroider';
 
-  if (tokens.includes('embroider')) {
+  if (tokens.includes(EMBROIDER)) {
     const RELATIVE_PATH_ROOT = 2;
 
-    tokens.splice(0, tokens.lastIndexOf('embroider') + RELATIVE_PATH_ROOT);
+    tokens.splice(0, tokens.lastIndexOf(EMBROIDER) + RELATIVE_PATH_ROOT);
     filename = tokens.join(path.sep);
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -30,21 +30,24 @@ function getNodeProperty(node, path) {
   return property;
 }
 
+function hasEmbroiderPrefix(filepath) {
+  const separator = filepath.includes('\\') ? '\\' : '/';
+  return (
+    typeof filepath === 'string' &&
+    filepath.split(separator).includes('embroider')
+  );
+}
+
 function stripEmbroiderPrefix(filepath) {
-  if (typeof filepath !== 'string') {
+  if (!hasEmbroiderPrefix(filepath)) {
     return;
   }
 
-  let separator = '/';
-  const windowsSeparator = '\\';
-
-  if (filepath.includes(windowsSeparator)) {
-    separator = windowsSeparator;
-  }
-
+  const separator = filepath.includes('\\') ? '\\' : '/';
   const tokens = filepath.split(separator);
+
   tokens.splice(0, tokens.indexOf('embroider') + 2);
   return tokens.join(separator);
 }
 
-module.exports = { getNodeProperty, stripEmbroiderPrefix };
+module.exports = { getNodeProperty, stripEmbroiderPrefix, hasEmbroiderPrefix };

--- a/src/utils.js
+++ b/src/utils.js
@@ -31,17 +31,14 @@ function getNodeProperty(node, path) {
 }
 
 function hasEmbroiderPrefix(filepath) {
+  if (typeof filepath !== 'string') return;
+
   const separator = filepath.includes('\\') ? '\\' : '/';
-  return (
-    typeof filepath === 'string' &&
-    filepath.split(separator).includes('embroider')
-  );
+  return filepath.split(separator).includes('embroider');
 }
 
-function stripEmbroiderPrefix(filepath) {
-  if (!hasEmbroiderPrefix(filepath)) {
-    return;
-  }
+function getEmbroiderStrippedPrefixPath(filepath) {
+  if (!hasEmbroiderPrefix(filepath)) return;
 
   const separator = filepath.includes('\\') ? '\\' : '/';
   const tokens = filepath.split(separator);
@@ -50,4 +47,8 @@ function stripEmbroiderPrefix(filepath) {
   return tokens.join(separator);
 }
 
-module.exports = { getNodeProperty, stripEmbroiderPrefix, hasEmbroiderPrefix };
+module.exports = {
+  getNodeProperty,
+  getEmbroiderStrippedPrefixPath,
+  hasEmbroiderPrefix,
+};

--- a/src/utils.js
+++ b/src/utils.js
@@ -30,6 +30,11 @@ function getNodeProperty(node, path) {
   return property;
 }
 
+/**
+ * Check if the file path follows an Embroider build pattern
+ * @param {string} filepath
+ * @returns boolean
+ */
 function hasEmbroiderPrefix(filepath) {
   if (typeof filepath !== 'string') return;
 
@@ -37,8 +42,13 @@ function hasEmbroiderPrefix(filepath) {
   return filepath.split(separator).includes('embroider');
 }
 
+/**
+ * Get a file path with the Embroider prefix segments stripped out
+ * @param {string} filepath  E.g. /private/var/folders/abcdefg1234/T/embroider/098765/tests/acceptance/my-test.js
+ * @returns {string} E.g. tests/acceptance/my-test.js
+ */
 function getEmbroiderStrippedPrefixPath(filepath) {
-  if (!hasEmbroiderPrefix(filepath)) return;
+  if (typeof filepath !== 'string') return;
 
   const separator = filepath.includes('\\') ? '\\' : '/';
   const tokens = filepath.split(separator);


### PR DESCRIPTION
There’s an issue with using this plugin in Embroider-built apps, in that the filePath value that is ultimately assigned to test metadata references a temp directory. For example: ../../../../../../tmp/embroider/07f011/tests/acceptance/application-test.js

This may cause issues for downstream consumers that function on a file path structure based on the project's actual/original (non temp) locations.

## The changes here:

- adds util that checks if `filename` (file path) is an Embroider prefixed path
- adds util that strips the Embroider prefix from the file path. For the example above, the result would be "tests/acceptance/application-test.js"
- adds unit & application tests

## Testing

- yarn test
- Also tested in large Ember + Embroider app