### PR TITLE
DRAFT Fix embroider tests

### DIFF
--- a/packages/test-scenarios/__tests__/scenario-test.js
+++ b/packages/test-scenarios/__tests__/scenario-test.js
@@ -14,6 +14,59 @@ function createTmpDir() {
 
 async function classic(project) {
   merge(project.files, {
+    tests: {
+      unit: {
+        'with-hooks-test.js': `import { module, test } from 'qunit';
+import { getTestMetadata } from '@ember/test-helpers';
+
+module('Acceptance | with-hooks-test', function (hooks) {
+hooks.beforeEach(function () {
+  // noop
+});
+
+test('example', async function (assert) {
+  assert.ok(getTestMetadata(this).filePath.includes('tests/unit/with-hooks-test.js'));
+});
+});
+`,
+        'without-hooks-test.js': `import { module, test } from 'qunit';
+import { getTestMetadata } from '@ember/test-helpers';
+
+module('Acceptance | without-hooks-test', function () {
+hooks.beforeEach(function () {
+  // noop
+});
+
+test('example', async function (assert) {
+  assert.ok(getTestMetadata(this).filePath.includes('tests/unit/without-hooks-test.js'));
+});
+});
+`,
+        'with-multiple-modules-test.js': `import {module, test} from 'qunit';
+import { getTestMetadata } from '@ember/test-helpers';
+
+module('Acceptance | with-multiple-modules-test', function (hooks) {
+hooks.beforeEach(function () {
+  // noop
+});
+
+test('example', async function (assert) {
+  assert.ok(getTestMetadata(this).filePath.includes('tests/unit/with-multiple-modules-test.js'));
+});
+});
+
+module('Acceptance | with-multiple-modules-test 2', function (hooks) {
+hooks.beforeEach(function () {
+  // noop
+});
+
+test('example', async function (assert) {
+  assert.ok(getTestMetadata(this).filePath.includes('tests/unit/with-multiple-modules-test.js'));
+});
+});
+`,
+      },
+    },
     'ember-cli-build.js': `'use strict';
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 module.exports = function (defaults) {
@@ -48,6 +101,59 @@ async function embroider(project) {
   });
 
   merge(project.files, {
+    tests: {
+      unit: {
+        'with-hooks-test.js': `import { module, test } from 'qunit';
+import { getTestMetadata } from '@ember/test-helpers';
+
+module('Acceptance | with-hooks-test', function (hooks) {
+hooks.beforeEach(function () {
+  // noop
+});
+
+test('example', async function (assert) {
+  assert.equal(getTestMetadata(this).filePath, 'tests/unit/with-hooks-test.js');
+});
+});
+`,
+        'without-hooks-test.js': `import { module, test } from 'qunit';
+import { getTestMetadata } from '@ember/test-helpers';
+
+module('Acceptance | without-hooks-test', function () {
+hooks.beforeEach(function () {
+  // noop
+});
+
+test('example', async function (assert) {
+  assert.equal(getTestMetadata(this).filePath, 'tests/unit/without-hooks-test.js');
+});
+});
+`,
+        'with-multiple-modules-test.js': `import {module, test} from 'qunit';
+import { getTestMetadata } from '@ember/test-helpers';
+
+module('Acceptance | with-multiple-modules-test', function (hooks) {
+hooks.beforeEach(function () {
+  // noop
+});
+
+test('example', async function (assert) {
+  assert.equal(getTestMetadata(this).filePath, 'tests/unit/with-multiple-modules-test.js');
+});
+});
+
+module('Acceptance | with-multiple-modules-test 2', function (hooks) {
+hooks.beforeEach(function () {
+  // noop
+});
+
+test('example', async function (assert) {
+  assert.equal(getTestMetadata(this).filePath, 'tests/unit/with-multiple-modules-test.js');
+});
+});
+`,
+      },
+    },
     'ember-cli-build.js': `'use strict';
 
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
@@ -89,62 +195,6 @@ Scenarios.fromProject(baseApp)
   .map('app scenarios', (project) => {
     project.linkDependency('babel-plugin-ember-test-metadata', {
       baseDir: __dirname,
-    });
-
-    merge(project.files, {
-      tests: {
-        unit: {
-          'with-hooks-test.js': `import { module, test } from 'qunit';
-import { getTestMetadata } from '@ember/test-helpers';
-
-module('Acceptance | with-hooks-test', function (hooks) {
-  hooks.beforeEach(function () {
-    // noop
-  });
-
-  test('example', async function (assert) {
-    assert.equal(getTestMetadata(this).filePath, 'tests/unit/with-hooks-test.js');
-  });
-});
-`,
-          'without-hooks-test.js': `import { module, test } from 'qunit';
-import { getTestMetadata } from '@ember/test-helpers';
-
-module('Acceptance | without-hooks-test', function () {
-  hooks.beforeEach(function () {
-    // noop
-  });
-
-  test('example', async function (assert) {
-    assert.ok(getTestMetadata(this).filePath.includes('tests/unit/without-hooks-test.js'));
-  });
-});
-`,
-          'with-multiple-modules-test.js': `import {module, test} from 'qunit';
-import { getTestMetadata } from '@ember/test-helpers';
-
-module('Acceptance | with-multiple-modules-test', function (hooks) {
-  hooks.beforeEach(function () {
-    // noop
-  });
-
-  test('example', async function (assert) {
-    assert.ok(getTestMetadata(this).filePath.includes('tests/unit/with-multiple-modules-test.js'));
-  });
-});
-
-module('Acceptance | with-multiple-modules-test 2', function (hooks) {
-  hooks.beforeEach(function () {
-    // noop
-  });
-
-  test('example', async function (assert) {
-    assert.ok(getTestMetadata(this).filePath.includes('tests/unit/with-multiple-modules-test.js'));
-  });
-});
-`,
-        },
-      },
     });
   })
   .forEachScenario((scenario) => {

--- a/packages/test-scenarios/package.json
+++ b/packages/test-scenarios/package.json
@@ -3,9 +3,11 @@
   "version": "0.0.0",
   "private": true,
   "dependencies": {
+    "fs-extra": "^9.1.0",
     "jest": "^27.1.1",
     "lodash": "^4.17.21",
-    "scenario-tester": "^1.0.2"
+    "scenario-tester": "^1.0.2",
+    "tmp": "^0.2.1"
   },
   "devDependencies": {
     "@babel-plugin-ember-test-metadata/app-template": "*",


### PR DESCRIPTION
Sets up the embroider-app scenario's prepared path and updates embroider tests to match on the exact expected path for all tests.

Before: Embroider's build step was building into a generated path like this: `/private/var/folders/2j/wk59f3qx2kl7zl34yr8yhn38000j2y/T/embroider/7eee16/private/var/folders/2j/wk59f3qx2kl7zl34yr8yhn38000j2y/T/tmp-72329-6SsJEomJQDVe`

After: the embroider scenario is still prepared in a tmp directory and embroider file path segments are appended like: `/private/var/folders/2j/wk59f3qx2kl7zl34yr8yhn38000j2y/T/embroider/7eee16/private/var/folders/2j/wk59f3qx2kl7zl34yr8yhn38000j2y/T/tmp-72329-6SsJEomJQDVe/embroider/999999`

TODO (in a separate PR)

- Branch, and update the CLASSIC tests to match on the exact expected path for all tests (eg. tests/unit/some-test.js)
