### PR TITLE
Add in repo test scenarios

### DIFF
--- a/packages/test-scenarios/__tests__/__fixtures__/with-hooks-test.js
+++ b/packages/test-scenarios/__tests__/__fixtures__/with-hooks-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { getTestMetadata } from '@ember/test-helpers';
+
+module('Acceptance | with-hooks-test', function (hooks) {
+  hooks.beforeEach(function () {
+    // noop
+  });
+
+  test('example', async function (assert) {
+    assert.ok(getTestMetadata(this).filePath.includes('tests/unit/with-hooks-test.js'));
+  });
+});

--- a/packages/test-scenarios/__tests__/__fixtures__/with-multiple-modules-test.js
+++ b/packages/test-scenarios/__tests__/__fixtures__/with-multiple-modules-test.js
@@ -1,0 +1,22 @@
+import { module, test } from 'qunit';
+import { getTestMetadata } from '@ember/test-helpers';
+
+module('Acceptance | with-multiple-modules-test', function (hooks) {
+  hooks.beforeEach(function () {
+    // noop
+  });
+
+  test('example', async function (assert) {
+    assert.ok(getTestMetadata(this).filePath.includes('tests/unit/with-multiple-modules-test.js'));
+  });
+});
+
+module('Acceptance | with-multiple-modules-test 2', function (hooks) {
+  hooks.beforeEach(function () {
+    // noop
+  });
+
+  test('example', async function (assert) {
+    assert.ok(getTestMetadata(this).filePath.includes('tests/unit/with-multiple-modules-test.js'));
+  });
+});

--- a/packages/test-scenarios/__tests__/__fixtures__/without-hooks-test.js
+++ b/packages/test-scenarios/__tests__/__fixtures__/without-hooks-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { getTestMetadata } from '@ember/test-helpers';
+
+module('Acceptance | without-hooks-test', function () {
+  hooks.beforeEach(function () {
+    // noop
+  });
+
+  test('example', async function (assert) {
+    assert.ok(getTestMetadata(this).filePath.includes('tests/unit/without-hooks-test.js'));
+  });
+});

--- a/packages/test-scenarios/package.json
+++ b/packages/test-scenarios/package.json
@@ -13,10 +13,17 @@
     "@embroider/core": "^0.44.1",
     "@embroider/webpack": "^0.44.1",
     "babel-plugin-ember-test-metadata": "*",
+    "ember-add-in-repo-tests": "^1.0.3",
     "webpack": "^5.52.0"
   },
   "scripts": {
     "test": "jest"
+  },
+  "jest": {
+    "testEnvironment": "node",
+    "testPathIgnorePatterns": [
+      "/__fixtures__/"
+    ]
   },
   "volta": {
     "extends": "../../package.json"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6589,6 +6589,15 @@ elliptic@^6.5.3:
     minimalistic-assert "^1.0.1"
     minimalistic-crypto-utils "^1.0.1"
 
+ember-add-in-repo-tests@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/ember-add-in-repo-tests/-/ember-add-in-repo-tests-1.0.3.tgz#56ddd352e71274b8c8fd2023d4c5a44b6d716ce8"
+  integrity sha512-x25N5hianfWUxs/xf2jQ3loRVZNB3lMZYZGlAus8I5XmG3Huk0RMIpe0odl3cHxisUstCo1MLn3mVB/A2XQnVw==
+  dependencies:
+    broccoli-funnel "^2.0.1"
+    broccoli-merge-trees "^2.0.0"
+    broccoli-source "^1.1.0"
+
 ember-auto-import@^1.10.1, ember-auto-import@^1.11.3:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/ember-auto-import/-/ember-auto-import-1.12.0.tgz#52246b04891090e2608244e65c4c6af7710df12b"


### PR DESCRIPTION
Adds tests for in-repo addon scenarios. Specifically, this handles the scenarios where we have in-repo addons with colocated tests, and the app uses `ember-add-in-repo-tests`. 

We only need to cover the in-repo addon scenario and not in-repo engines as the latter is virtually identical to the addon case, and is redundant.