### PR TITLE
Fixes incorrect file paths for duplicate segments in classic workspaces

### DIFF
--- a/packages/babel-plugin-ember-test-metadata/__tests__/get-relative-paths-test.js
+++ b/packages/babel-plugin-ember-test-metadata/__tests__/get-relative-paths-test.js
@@ -98,6 +98,18 @@ describe('get-relative-paths', () => {
         projectRoot: '../../..',
         expected: 'foo/packages/classic/tests/acceptance/foo-test.js',
       },
+      {
+        filePath: '/Users/tester/projects/classic-web/packages/classic-web/classic-web/tests/acceptance/foo-test.js',
+        packageName: 'classic-web',
+        projectRoot: '../..',
+        expected: 'packages/classic-web/tests/acceptance/foo-test.js',
+      },
+      {
+        filePath: '/Users/tester/projects/classic-web/packages/classic-web/@scoped/classic-web/tests/acceptance/foo-test.js',
+        packageName: 'classic-web',
+        projectRoot: '../..',
+        expected: 'packages/classic-web/tests/acceptance/foo-test.js',
+      },
     ];
 
     testCases.forEach(({ filePath, packageName, projectRoot, expected }) => {
@@ -222,6 +234,13 @@ describe('get-relative-paths', () => {
         packageName: 'example-app',
         projectRoot: '../../../..',
         expected: 'bar/baz/packages/example-app/tests/acceptance/foo-test.js',
+      },
+      {
+        filePath:
+          '/private/var/folders/24/v9y37q75019cv62vg5ms10tw001llm/T/embroider/620a67/foo/example-app/packages/example-app/tests/acceptance/foo-test.js',
+        packageName: 'example-app',
+        projectRoot: '../..',
+        expected: 'packages/example-app/tests/acceptance/foo-test.js',
       },
     ];
 

--- a/packages/babel-plugin-ember-test-metadata/get-relative-paths.js
+++ b/packages/babel-plugin-ember-test-metadata/get-relative-paths.js
@@ -6,7 +6,7 @@ function _getNormalizedPackageDir(packageName) {
 }
 
 function _getRelativeProjectPath(pathSegments, projectDir, projectRoot) {
-  const appRoot = pathSegments.slice(0, pathSegments.indexOf(projectDir) + 1);
+  const appRoot = pathSegments.slice(0, pathSegments.lastIndexOf(projectDir) + 1);
   const projectBaseDir = basename(resolve(appRoot.join(sep), projectRoot));
 
   return appRoot.slice(appRoot.indexOf(projectBaseDir) + 1).join(sep);
@@ -16,11 +16,15 @@ function _getRelativePathForClassic(filePath, packageName, projectRoot) {
   const projectDir = _getNormalizedPackageDir(packageName);
   const pathSegments = filePath.split(sep);
   const testFilePath = pathSegments
-    .slice(pathSegments.lastIndexOf(projectDir) + 1)
+    .splice(pathSegments.lastIndexOf(projectDir) + 1)
     .join(sep);
 
   if (!projectRoot) {
     return testFilePath;
+  }
+
+  if (pathSegments.lastIndexOf(projectDir, -2) > -1) {
+    pathSegments.pop();
   }
 
   const projectPath = _getRelativeProjectPath(pathSegments, projectDir, projectRoot);


### PR DESCRIPTION
## Summary
This code change fixes an issue in classic builds utilizing workspaces, where the Ember app dir and project dir share the same name.

For example, given a test file path such as
`/Users/jdoe/projects/classic-web/packages/classic-web/tests/acceptance/foo-test.js`,
results in the following `projects/classic-web/tests/acceptance/foo-test.js`,
instead of the expected `packages/classic-web/tests/acceptance/foo-test.js`.

The root cause is from prematurely slicing on the first instance of `classic-web` (the specified package name). The fix updates the logic to slice on the last instance, while also adding some normalization for the end-duplication of the package name.

## Testing Done
Tests pass.
```sh
$ npm-run-all lint test:*
$ eslint .
$ yarn workspace babel-plugin-ember-test-metadata test
$ BABEL_TEST_METADATA=true yarn test:jest
$ jest
 PASS  __tests__/get-normalized-file-path-test.js
 PASS  __tests__/get-relative-paths-test.js
 PASS  __tests__/index-test.js

Test Suites: 3 passed, 3 total
Tests:       22 passed, 22 total
Snapshots:   6 passed, 6 total
Time:        1.919 s, estimated 2 s
Ran all test suites.
$ yarn workspace @babel-plugin-ember-test-metadata/test-scenarios test
$ jest
 PASS  __tests__/workspace-scenario-test.js (119.1 s)
 PASS  __tests__/scenario-test.js (120.217 s)

Test Suites: 2 passed, 2 total
Tests:       8 passed, 8 total
Snapshots:   0 total
Time:        120.685 s, estimated 125 s
Ran all test suites.
✨  Done in 131.94s.
```
Manually validated on a workspace project.