### PR TITLE
Update `getCustomNormalizedFilePath` from a function to a resolved path

### DIFF
--- a/packages/babel-plugin-ember-test-metadata/README.md
+++ b/packages/babel-plugin-ember-test-metadata/README.md
@@ -115,14 +115,27 @@ module.exports = function (defaults) {
 
 You can also pass a custom function to normalize the test file path.
 ```js
+/**
+  * Get a normalized file path
+  * @param {string} options.packageName the name of the package as specified in Babel plugin options
+  * @param {boolean} options.isUsingEmbroider whether building using Embroider as specified in Babel plugin options
+  * @param {boolean} options.projectRoot custom relative path to the project's root as specified in Babel plugin options
+  * @param {string} options.filename the absolute perceived path of the file being visited
+  * @param {string} options.root the absolute root project path as seen on disk
+}
+*/
+module.exports = function customNormalizedFilePath(options) {
+    // Custom normalization
+}
+```
+
+
+```js
 'use strict';
 
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
 
 module.exports = function (defaults) {
-  function customNormalizedFilePath(filePath, packageName, projectRoot) {
-    // Custom normalization
-  }
 
   let app = new EmberApp(defaults, {
     babel: {
@@ -133,7 +146,7 @@ module.exports = function (defaults) {
             enabled: !!process.env.BABEL_TEST_METADATA,
             packageName: defaults.project.pkg.name,
             packageRoot: '../..',
-            getCustomNormalizedFilePath: customNormalizedFilePath,
+            getCustomNormalizedFilePath: require.resolve('path/to/your/customNormalizedFilePath/function'),
           },
         ],
       ],

--- a/packages/babel-plugin-ember-test-metadata/__tests__/__fixtures__/get-custom-normalized-file-path.js
+++ b/packages/babel-plugin-ember-test-metadata/__tests__/__fixtures__/get-custom-normalized-file-path.js
@@ -1,0 +1,12 @@
+const { join, sep } = require('path');
+
+module.exports = function normalizeBuildIsolationPath(options) {
+    const pathSegments = options.filename.split(sep);
+    const testFilePath = pathSegments
+      .slice(pathSegments.indexOf('tests'))
+      .join(sep);
+
+    const projectPath = pathSegments.slice(pathSegments.indexOf(options.packageName) + 1, pathSegments.indexOf('tests') - 1).join(sep);
+
+    return join(projectPath, testFilePath);
+}

--- a/packages/babel-plugin-ember-test-metadata/__tests__/get-normalized-file-path-test.js
+++ b/packages/babel-plugin-ember-test-metadata/__tests__/get-normalized-file-path-test.js
@@ -1,4 +1,3 @@
-const { join, sep } = require('path');
 const { getNormalizedFilePath } = require('../get-normalized-file-path');
 
 describe('getNormalizedFilePath', () => {
@@ -163,24 +162,13 @@ describe('getNormalizedFilePath', () => {
   describe('custom normalized filePath function', () => {
     const appRoot = '/Users/tester/workspace/personal/test-bed/example-app';
 
-    function normalizeBuildIsolationPath(options) {
-        const pathSegments = options.filename.split(sep);
-        const testFilePath = pathSegments
-          .slice(pathSegments.indexOf('tests'))
-          .join(sep);
-
-        const projectPath = pathSegments.slice(pathSegments.indexOf(options.packageName) + 1, pathSegments.indexOf('tests') - 1).join(sep);
-
-        return join(projectPath, testFilePath);
-      }
-
     it('returns the normalized filepath for build isolation addon test', () => {
       const filePath = `${appRoot}/packages/addons/example-addon/example-app/tests/acceptance/foo-test.js`;
       const expectedPath = 'packages/addons/example-addon/tests/acceptance/foo-test.js';
       const opts = {
         filename: filePath,
         packageName: 'example-app',
-        getCustomNormalizedFilePath: normalizeBuildIsolationPath,
+        getCustomNormalizedFilePath: require.resolve('./__fixtures__/get-custom-normalized-file-path.js'),
       };
 
       const normalizedFilePath = getNormalizedFilePath(opts);

--- a/packages/babel-plugin-ember-test-metadata/get-normalized-file-path.js
+++ b/packages/babel-plugin-ember-test-metadata/get-normalized-file-path.js
@@ -18,10 +18,11 @@ const {
  * @returns {string} E.g. tests/acceptance/my-test.js
  */
 function getNormalizedFilePath({ packageName, getCustomNormalizedFilePath, isUsingEmbroider, projectRoot, filename, root }) {
-  if (typeof getCustomNormalizedFilePath === 'function') {
+  if (getCustomNormalizedFilePath) {
+    const customNormalizedFilePath = require(getCustomNormalizedFilePath);
     const options = { packageName, isUsingEmbroider, projectRoot, filename, root };
   
-    return getCustomNormalizedFilePath(options);
+    return customNormalizedFilePath(options);
   } else if (!isUsingEmbroider) {
     if (filename.includes('ember-add-in-repo-tests')) {
       return _getRelativePathForClassicInRepo(filename);

--- a/packages/babel-plugin-ember-test-metadata/get-normalized-file-path.js
+++ b/packages/babel-plugin-ember-test-metadata/get-normalized-file-path.js
@@ -1,4 +1,5 @@
 const { join, parse } = require('path');
+const { existsSync } = require('fs');
 const {
   _getRelativePathForClassic,
   _getRelativePathForClassicInRepo,
@@ -19,8 +20,12 @@ const {
  */
 function getNormalizedFilePath({ packageName, getCustomNormalizedFilePath, isUsingEmbroider, projectRoot, filename, root }) {
   if (getCustomNormalizedFilePath) {
-    const customNormalizedFilePath = require(getCustomNormalizedFilePath);
-    const options = { packageName, isUsingEmbroider, projectRoot, filename, root };
+    if (existsSync(getCustomNormalizedFilePath)) {
+      const customNormalizedFilePath = require(getCustomNormalizedFilePath);
+      const options = { packageName, isUsingEmbroider, projectRoot, filename, root };
+    } else {
+      throw new Error(`The custom normalized file path function specified in your Babel config does not exist at ${getCustomNormalizedFilePath}`);
+    }
   
     return customNormalizedFilePath(options);
   } else if (!isUsingEmbroider) {

--- a/packages/babel-plugin-ember-test-metadata/get-normalized-file-path.js
+++ b/packages/babel-plugin-ember-test-metadata/get-normalized-file-path.js
@@ -23,11 +23,11 @@ function getNormalizedFilePath({ packageName, getCustomNormalizedFilePath, isUsi
     if (existsSync(getCustomNormalizedFilePath)) {
       const customNormalizedFilePath = require(getCustomNormalizedFilePath);
       const options = { packageName, isUsingEmbroider, projectRoot, filename, root };
+
+      return customNormalizedFilePath(options);
     } else {
       throw new Error(`The custom normalized file path function specified in your Babel config does not exist at ${getCustomNormalizedFilePath}`);
     }
-  
-    return customNormalizedFilePath(options);
   } else if (!isUsingEmbroider) {
     if (filename.includes('ember-add-in-repo-tests')) {
       return _getRelativePathForClassicInRepo(filename);


### PR DESCRIPTION
## Summary
Previously the `getCustomNormalizedFilePath` babel option is a function, this results a problem in the build process.
```shell
strict mode: "items" is 1-tuple, but minItems or maxItems/additionalItems are not specified or different at path "#/properties/views"
[broccoli-persistent-filter:Babel > [Babel: appreciation-test-helpers]: Babel: appreciation-test-helpers] was configured to `throwUnlessParallelizable` and was unable to parallelize a plugin.
```
Instead we can change the `getCustomNormalizedFilePath` option's type to a filePath, so we can walk around the problem.