### PR TITLE
[Bug] Fix test file paths for Ember addon project

### DIFF
--- a/packages/babel-plugin-ember-test-metadata/__tests__/get-normalized-file-path-test.js
+++ b/packages/babel-plugin-ember-test-metadata/__tests__/get-normalized-file-path-test.js
@@ -18,6 +18,20 @@ describe('getNormalizedFilePath', () => {
       expect(normalizedFilePath).toEqual(expectedPath);
     });
 
+    it('returns the normalized filepath for ember addon tests', () => {
+      const filePath = `${appRoot}/classic/dummy/tests/acceptance/foo-test.js`;
+      const expectedPath = 'tests/acceptance/foo-test.js';
+      const opts = {
+        filename: filePath,
+        root: appRoot,
+        packageName: 'classic',
+      };
+
+      const normalizedFilePath = getNormalizedFilePath(opts);
+
+      expect(normalizedFilePath).toEqual(expectedPath);
+    });
+
     it('returns the normalized filepath for the in app test', () => {
       const filePath = `${appRoot}/classic/tests/acceptance/foo-test.js`;
       const expectedPath = 'tests/acceptance/foo-test.js';

--- a/packages/babel-plugin-ember-test-metadata/__tests__/get-relative-paths-test.js
+++ b/packages/babel-plugin-ember-test-metadata/__tests__/get-relative-paths-test.js
@@ -34,6 +34,11 @@ describe('get-relative-paths', () => {
         packageName: '@scoped/classic',
         expected: 'tests/acceptance/foo-test.js',
       },
+      {
+        filePath: '/Users/tester/workspace/foo/classic/classic/dummy/tests/acceptance/subdir/foo-test.js',
+        packageName: 'classic',
+        expected: 'tests/acceptance/subdir/foo-test.js',
+      },
     ];
 
     testCases.forEach(({ filePath, packageName, expected }) => {

--- a/packages/babel-plugin-ember-test-metadata/get-relative-paths.js
+++ b/packages/babel-plugin-ember-test-metadata/get-relative-paths.js
@@ -14,7 +14,7 @@ function _getRelativeProjectPath(pathSegments, projectDir, projectRoot) {
 
 function _getRelativePathForClassic(filePath, packageName, projectRoot) {
   const projectDir = _getNormalizedPackageDir(packageName);
-  const pathSegments = filePath.split(sep).filter(item => item !== 'dummy')
+  const pathSegments = filePath.split(sep).filter(segment => segment !== 'dummy')
   const testFilePath = pathSegments
     .splice(pathSegments.lastIndexOf(projectDir) + 1)
     .join(sep);

--- a/packages/babel-plugin-ember-test-metadata/get-relative-paths.js
+++ b/packages/babel-plugin-ember-test-metadata/get-relative-paths.js
@@ -14,7 +14,7 @@ function _getRelativeProjectPath(pathSegments, projectDir, projectRoot) {
 
 function _getRelativePathForClassic(filePath, packageName, projectRoot) {
   const projectDir = _getNormalizedPackageDir(packageName);
-  const pathSegments = filePath.split(sep).filter(segment => segment !== 'dummy')
+  const pathSegments = filePath.split(sep).filter((segment) => segment !== 'dummy');
   const testFilePath = pathSegments
     .splice(pathSegments.lastIndexOf(projectDir) + 1)
     .join(sep);

--- a/packages/babel-plugin-ember-test-metadata/get-relative-paths.js
+++ b/packages/babel-plugin-ember-test-metadata/get-relative-paths.js
@@ -14,7 +14,7 @@ function _getRelativeProjectPath(pathSegments, projectDir, projectRoot) {
 
 function _getRelativePathForClassic(filePath, packageName, projectRoot) {
   const projectDir = _getNormalizedPackageDir(packageName);
-  const pathSegments = filePath.split(sep);
+  const pathSegments = filePath.split(sep).filter(item => item !== 'dummy')
   const testFilePath = pathSegments
     .splice(pathSegments.lastIndexOf(projectDir) + 1)
     .join(sep);


### PR DESCRIPTION
Currently `babel-plugin-ember-test-metadata` can not report correct path for Ember addon. For example, it will report filePath like 

`"filePath":"dummy/tests/integration/components/metadata/skills-test.js" `

instead of

`"filePath":"tests/integration/components/metadata/skills-test.js" `

This PR will fix this problem by removing "dummy" in the path segments